### PR TITLE
Add Chef CI Cookbook Template Dependencies

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -56,3 +56,6 @@ suites:
          master:
            user: 'centos'
            group: 'centos'
+  - name: chef_ci_cookbook_template
+    run_list:
+      - recipe[osl-jenkins::chef_ci_cookbook_template]

--- a/Berksfile
+++ b/Berksfile
@@ -9,4 +9,6 @@ cookbook 'osl-haproxy', git: 'git@github.com:osuosl-cookbooks/osl-haproxy'
 cookbook 'resource_from_hash',
          git: 'git@github.com:osuosl-cookbooks/resource_from_hash'
 
+cookbook 'chef-dk', '~> 3.0.0'
+
 metadata

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Installs the `knife-backup` gem for use by the chef\_client, and ensures
 the `/var/chef-backup-for-rdiff` directory exists and is owned by the
 jenkins master user and group.
 
+#### osl-jenkins::chef_ci_cookbook_template
+Manages dependencies for the `chef-ci-cookbook-template` Jenkins job.
+
+Installs `foodcritic` and `rubocop` as chef gems.
+
 Contributing
 ------------
 TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jenkins master user and group.
 #### osl-jenkins::chef_ci_cookbook_template
 Manages dependencies for the `chef-ci-cookbook-template` Jenkins job.
 
-Installs `foodcritic` and `rubocop` as chef gems.
+Uses the `chef-dk::default` recipe to install `chefdk`.
 
 Contributing
 ------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,4 @@ version          '0.3.0'
 
 depends          'jenkins'
 depends          'osl-haproxy'
+depends          'chef-dk'

--- a/recipes/chef_ci.rb
+++ b/recipes/chef_ci.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: osl-jenkins
+# Recipe:: chef_ci
+#
+# Copyright 2015 Oregon State University
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+chef_gem 'foodcritic' do
+    action :install
+    version '4.0.0'
+end
+
+chef_gem 'rubocop' do
+    action :install
+    version '0.27.1'
+end

--- a/recipes/chef_ci_cookbook_template.rb
+++ b/recipes/chef_ci_cookbook_template.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: osl-jenkins
-# Recipe:: chef_ci
+# Recipe:: chef_ci_cookbook_template
 #
 # Copyright 2015 Oregon State University
 # 

--- a/recipes/chef_ci_cookbook_template.rb
+++ b/recipes/chef_ci_cookbook_template.rb
@@ -16,12 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-chef_gem 'foodcritic' do
-  action :install
-  version '4.0.0'
-end
-
-chef_gem 'rubocop' do
-  action :install
-  version '0.30.1'
-end
+include_recipe 'chef-dk::default'

--- a/recipes/chef_ci_cookbook_template.rb
+++ b/recipes/chef_ci_cookbook_template.rb
@@ -23,5 +23,5 @@ end
 
 chef_gem 'rubocop' do
   action :install
-  version '0.27.1'
+  version '0.30.1'
 end

--- a/recipes/chef_ci_cookbook_template.rb
+++ b/recipes/chef_ci_cookbook_template.rb
@@ -3,13 +3,13 @@
 # Recipe:: chef_ci_cookbook_template
 #
 # Copyright 2015 Oregon State University
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,11 +17,11 @@
 # limitations under the License.
 
 chef_gem 'foodcritic' do
-    action :install
-    version '4.0.0'
+  action :install
+  version '4.0.0'
 end
 
 chef_gem 'rubocop' do
-    action :install
-    version '0.27.1'
+  action :install
+  version '0.27.1'
 end

--- a/test/integration/chef_ci_cookbook_template/serverspec/chef_ci_cookbook_template_spec.rb
+++ b/test/integration/chef_ci_cookbook_template/serverspec/chef_ci_cookbook_template_spec.rb
@@ -1,0 +1,18 @@
+require 'serverspec'
+
+set :backend, :exec
+
+RSpec.configure do |config|
+  config.before(:all) do
+    config.path = '/opt/chef/embedded/bin:/usr/local/sbin:
+                   /usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  end
+end
+
+describe package('foodcritic') do
+  it { should be_installed.by('gem').with_version('4.0.0') }
+end
+
+describe package('rubocop') do
+  it { should be_installed.by('gem').with_version('0.27.1') }
+end

--- a/test/integration/chef_ci_cookbook_template/serverspec/chef_ci_cookbook_template_spec.rb
+++ b/test/integration/chef_ci_cookbook_template/serverspec/chef_ci_cookbook_template_spec.rb
@@ -2,17 +2,14 @@ require 'serverspec'
 
 set :backend, :exec
 
-RSpec.configure do |config|
-  config.before(:all) do
-    config.path = '/opt/chef/embedded/bin:/usr/local/sbin:
-                   /usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  end
+describe package('chefdk') do
+  it { should be_installed }
 end
 
-describe package('foodcritic') do
-  it { should be_installed.by('gem').with_version('4.0.0') }
+describe command('foodcritic --version') do
+  its(:stdout) { should match /foodcritic 4.0.0/ }
 end
 
-describe package('rubocop') do
-  it { should be_installed.by('gem').with_version('0.30.1') }
+describe command('rubocop --version') do
+  its(:stdout) { should match /0.28.0/ }
 end

--- a/test/integration/chef_ci_cookbook_template/serverspec/chef_ci_cookbook_template_spec.rb
+++ b/test/integration/chef_ci_cookbook_template/serverspec/chef_ci_cookbook_template_spec.rb
@@ -14,5 +14,5 @@ describe package('foodcritic') do
 end
 
 describe package('rubocop') do
-  it { should be_installed.by('gem').with_version('0.27.1') }
+  it { should be_installed.by('gem').with_version('0.30.1') }
 end


### PR DESCRIPTION
Installs:

* foodcritic
* rubocop

using the `chef-dk` cookbook. This is for the `chef-ci-cookbook-template` job.