### PR TITLE
Rubocop Fixes

### DIFF
--- a/test/integration/chef_ci_cookbook_template/serverspec/chef_ci_cookbook_template_spec.rb
+++ b/test/integration/chef_ci_cookbook_template/serverspec/chef_ci_cookbook_template_spec.rb
@@ -7,9 +7,9 @@ describe package('chefdk') do
 end
 
 describe command('foodcritic --version') do
-  its(:stdout) { should match /foodcritic 4.0.0/ }
+  its(:stdout) { should match(/foodcritic 4.0.0/) }
 end
 
 describe command('rubocop --version') do
-  its(:stdout) { should match /0.28.0/ }
+  its(:stdout) { should match(/0.28.0/) }
 end


### PR DESCRIPTION
Fix the one issue raised by rubocop:

-  ``W: Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal ...``