### PR TITLE
Install jdk 8 for jenkins client.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 #
 
 # jenkins 1.612 and above requires java 7
-node.default['java']['jdk_version'] = '7'
+node.default['java']['jdk_version'] = '8'
 
 include_recipe 'java'
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -2,7 +2,7 @@ require 'serverspec'
 
 set :backend, :exec
 
-describe package('java-1.7.0-openjdk') do
+describe package('java-1.8.0-openjdk') do
   it { should be_installed }
 end
 


### PR DESCRIPTION
The project has stated their desire to move to Java 8 in late
2016. We might as well use the latest version.