### PR TITLE
Manually set jenkins java path to stop restarts during chef runs

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -28,6 +28,11 @@ package 'graphviz'
 
 node.default['java']['jdk_version'] = '8'
 
+# Manually set the jenkins java attribute to stop jenkins being restarted
+# every chef run due to logic in
+# https://github.com/chef-cookbooks/jenkins/blob/master/attributes/default.rb#L45-L53
+node.set['jenkins']['java'] = 'java'
+
 node.default['certificate'] = [{
   'wildcard' => {
     'cert_file' => 'wildcard.pem',


### PR DESCRIPTION
The logic in
https://github.com/chef-cookbooks/jenkins/blob/master/attributes/default.rb#L45-L53
is causing chef to restart runs every time.