### PR TITLE
Lock version per plugin

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,6 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'osl-haproxy', git: 'git@github.com:osuosl-cookbooks/osl-haproxy'
 cookbook 'osl-munin', git: 'git@github.com:osuosl-cookbooks/osl-munin'
 

--- a/libraries/github.rb
+++ b/libraries/github.rb
@@ -22,9 +22,6 @@ end
 # of the comment to the specified Jenkins job, using the given trigger token to
 # authenticate with Jenkins (otherwise, the trigger would be ignored).
 #
-# @param auth_user [String] Jenkins user for authentication with Jenkins server
-# @param auth_token [String] Jenkins user api token for authentication with
-#   Jenkins server
 # @param github_token [String] GitHub API token with permissions to create
 #   hooks on the given repo.
 # @param org_name [String] Name of GitHub organization.
@@ -33,6 +30,9 @@ end
 # @param trigger_token [String] A trigger token to authenticate with Jenkins.
 # @param insecure_hook [Boolean] Whether to allow triggering Jenkins over
 #   insecure connection (useful for testing).
+# @param auth_user [String] Jenkins user for authentication with Jenkins server
+# @param auth_token [String] Jenkins user api token for authentication with
+#   Jenkins server
 #
 # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/ParameterLists
 def set_up_github_push(github_token, org_name, repo_name, job_name,

--- a/libraries/github.rb
+++ b/libraries/github.rb
@@ -35,9 +35,9 @@ end
 #   insecure connection (useful for testing).
 #
 # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/ParameterLists
-def set_up_github_push(auth_user = nil, auth_token = nil, github_token,
-                       org_name, repo_name, job_name, trigger_token,
-                       insecure_hook)
+def set_up_github_push(github_token, org_name, repo_name, job_name,
+                       trigger_token, insecure_hook, auth_user = nil,
+                       auth_token = nil)
   chef_gem 'octokit' do # ~FC009
     compile_time true
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          'Apache 2.0'
 description      'Installs/Configures osl-jenkins'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.7.22'
+issues_url       'https://github.com/osuosl-cookbooks/osl-jenkins/issues'
+source_url       'https://github.com/osuosl-cookbooks/osl-jenkins'
 
 depends          'chef-dk'
 depends          'git', '~> 4.3'

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -72,7 +72,7 @@ rescue Net::HTTPServerException => e
 end
 
 # This is necessary in order to create Jenkins jobs with security enabled.
-node.run_state['jenkins_private_key'] = secrets['jenkins_private_key']
+node.run_state[:jenkins_private_key] = secrets['jenkins_private_key'] # ~FC001
 
 # Create a Git credentials file so we can access repos using our API token.
 # This obviates the need for an ssh key.

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -19,14 +19,22 @@
 
 include_recipe 'osl-jenkins::master'
 
+# Lock version per plugin so it doesn't install latest on every run.
 # git and github: for git
 # build-token-root: for triggering from Github PRs
 # parameterized-trigger: for triggering other jobs (e.g. the environment-bumper
 #   job) with parameters
 # text-finder: for marking unstable builds (used in this case to mark builds
 #   where no action was taken)
-%w(git github build-token-root parameterized-trigger text-finder).each do |p|
+{
+  'git' => '2.5.2',
+  'github' => '1.19.1',
+  'build-token-root' => '1.4',
+  'parameterized-trigger' => '2.30',
+  'text-finder' => '1.10'
+}.each do |p, v|
   jenkins_plugin p do
+    version v
     notifies :restart, 'service[jenkins]'
   end
 end

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -169,14 +169,14 @@ repo_names.each do |repo_name|
     action [:create, :enable]
   end
   set_up_github_push(
-    secrets['jenkins_user'],
-    secrets['jenkins_api_token'],
     secrets['github_token'],
     org_name,
     repo_name,
     job_name,
     secrets['trigger_token'],
-    node['osl-jenkins']['cookbook_uploader']['github_insecure_hook']
+    node['osl-jenkins']['cookbook_uploader']['github_insecure_hook'],
+    secrets['jenkins_user'],
+    secrets['jenkins_api_token']
   )
 end
 

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -72,7 +72,7 @@ rescue Net::HTTPServerException => e
 end
 
 # This is necessary in order to create Jenkins jobs with security enabled.
-node.run_state[:jenkins_private_key] = secrets['jenkins_private_key']
+node.run_state['jenkins_private_key'] = secrets['jenkins_private_key']
 
 # Create a Git credentials file so we can access repos using our API token.
 # This obviates the need for an ssh key.


### PR DESCRIPTION
This uses versions as they are currently installed in prod. This should work around the issue we're having with chef runs on jenkins1. Tests will come in a later PR as its ... complicated.