### PR TITLE
Create recipe for jenkins1.o.o that replicates roles

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -82,12 +82,45 @@ suites:
     provisioner: chef_zero
     driver:
       security_groups:
-        - no-firewall
+        - default
+        - github
     attributes:
       osl-jenkins:
         cookbook_uploader:
           override_repos:
-            - lanparty
+            - test-cookbook
+          github_insecure_hook: true
+          do_not_upload_cookbooks: true
+          credentials:
+            github_user: <%= ENV['GITHUB_USER'] %>
+            github_token: <%= ENV['GITHUB_TOKEN'] %>
+            trigger_token: <%= ENV['TRIGGER_TOKEN'] %>
+            jenkins_user: <%= ENV['JENKINS_USER'] %>
+            jenkins_pass: <%= ENV['JENKINS_PASS'] %>
+      jenkins:
+        master:
+          listen_address: '0.0.0.0'
+      certificate:
+        - snakeoil:
+            cert_path: "/etc/pki/tls"
+            cert_file: wildcard.pem
+            key_file: wildcard.key
+            chain_file: wildcard-bundle.crt
+            combined_file: true
+  # See documentation from cookbook-uploader suite on how to run this suite
+  - name: jenkins1
+    encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
+    run_list:
+      - recipe[osl-jenkins::jenkins1]
+    driver:
+      security_groups:
+        - default
+        - github
+    attributes:
+      osl-jenkins:
+        cookbook_uploader:
+          override_repos:
+            - test-cookbook
           github_insecure_hook: true
           do_not_upload_cookbooks: true
           credentials:

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ issues_url       'https://github.com/osuosl-cookbooks/osl-jenkins/issues'
 source_url       'https://github.com/osuosl-cookbooks/osl-jenkins'
 
 depends          'base'
+depends          'build-essential'
 depends          'git', '~> 4.3'
 depends          'java'
 depends          'jenkins', '~> 2.4.0'

--- a/recipes/jenkins1.rb
+++ b/recipes/jenkins1.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook:: osl-jenkins
+# Recipe:: jenkins1
+#
+# Copyright:: 2017, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_recipe 'osl-jenkins::master'
+include_recipe 'osl-jenkins::chef_ci_cookbook_template'
+include_recipe 'osl-jenkins::osl_cookbook_uploader'
+
+python_runtime '2'
+
+# depends for sphinx compilation
+package 'graphviz'

--- a/recipes/jenkins1.rb
+++ b/recipes/jenkins1.rb
@@ -15,6 +15,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+node.default['osl-jenkins']['cookbook_uploader'].tap do |conf|
+  conf['authorized_teams'] = %w(osuosl-cookbooks/staff)
+  conf['chef_repo'] = 'osuosl/chef-repo'
+  conf['default_environments'] = %w(
+    production
+    workstation
+    openstack_production
+    openstack_staging
+    phpbb
+  )
+  conf['org'] = 'osuosl-cookbooks'
+end
+
 include_recipe 'osl-jenkins::master'
 include_recipe 'osl-jenkins::chef_ci_cookbook_template'
 include_recipe 'osl-jenkins::osl_cookbook_uploader'

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -23,9 +23,6 @@ node.override['yum-cron']['yum_parameter'] = '-x jenkins'
 node.default['jenkins']['master']['version'] = '1.654-1.1'
 node.default['jenkins']['master']['listen_address'] = '127.0.0.1'
 
-# depends for sphinx compilation
-package 'graphviz'
-
 node.default['java']['jdk_version'] = '8'
 
 # Manually set the jenkins java attribute to stop jenkins being restarted
@@ -57,6 +54,7 @@ if platform_family?('rhel')
     node.set['git']['version'] = '1.8.5.5'
     node.set['git']['checksum'] = '106b480e2b3ae8b02e5b6b099d7a4049' \
                                   'f2b1128659ac81f317267d2ed134679f'
+    include_recipe 'build-essential'
     include_recipe 'git::source'
 
     # Also create a symlink for when /usr/local/bin isn't in PATH.
@@ -68,7 +66,3 @@ if platform_family?('rhel')
     include_recipe 'git::package'
   end
 end
-
-include_recipe 'osl-jenkins::chef_ci_cookbook_template'
-
-python_runtime '2'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,26 @@ CENTOS_6_OPTS = {
   version: '6.7'
 }.freeze
 
+ALL_PLATFORMS = [
+  CENTOS_6_OPTS,
+  CENTOS_7_OPTS
+].freeze
+
 RSpec.configure do |config|
   config.log_level = :fatal
+end
+
+shared_context 'cookbook_uploader' do
+  before do
+    allow_any_instance_of(Chef::Recipe).to receive(:set_up_github_push)
+    allow(Chef::EncryptedDataBagItem).to receive(:load).with('osl_jenkins', 'cookbook_uploader_secrets')
+      .and_return(
+        jenkins_private_key: 'private_key',
+        github_user: 'manatee',
+        github_token: 'github_token',
+        trigger_token: 'trigger_token',
+        jenkins_user: 'jenkins',
+        jenkins_api_token: 'jenkins_api_token'
+      )
+  end
 end

--- a/spec/unit/recipes/jenkins1_spec.rb
+++ b/spec/unit/recipes/jenkins1_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../spec_helper'
+
+describe 'osl-jenkins::jenkins1' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p) do |node|
+          node.set['osl-jenkins']['cookbook_uploader'] = {
+            'override_repos' => %w(test-cookbook),
+            'github_insecure_hook' => true,
+            'do_not_upload_cookbooks' => true
+          }
+        end.converge(described_recipe)
+      end
+      include_context 'cookbook_uploader'
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+    end
+  end
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,18 @@
+require 'serverspec'
+set :backend, :exec
+
+shared_examples_for 'jenkins_server' do
+  describe package('java-1.8.0-openjdk') do
+    it { should be_installed }
+  end
+
+  describe package('jenkins') do
+    it { should be_installed.with_version('1.654-1.1') }
+  end
+
+  %w(80 443 8080).each do |p|
+    describe port(p) do
+      it { should be_listening }
+    end
+  end
+end

--- a/test/integration/jenkins1/serverspec/jenkins1_spec.rb
+++ b/test/integration/jenkins1/serverspec/jenkins1_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'jenkins1' do
+  it_behaves_like 'jenkins_server'
+end

--- a/test/smoke/default/jenkins1.rb
+++ b/test/smoke/default/jenkins1.rb
@@ -1,0 +1,6 @@
+# # encoding: utf-8
+
+# Inspec test for recipe osl-jenkins::jenkins1
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/


### PR DESCRIPTION
This moves all of the logic we have currently in roles for jenkins1.osuosl.org
into it's own recipe to test it easier. This also moves specific changes for
jenkins1 out of the master recipe. The master recipe was pulling in things it
shouldn't be such as chefdk due to the inclusion of the cookbook uploader
recipe. This simplifies it for easier testing of other new recipes down the
road.

In addition, I also made these changes and/or fixes:

- Updated the repo to use to test to test-cookbook (lanparty was removed)
- Created a github security group on OpenStack so that we don't leave these
  instance wide open to the internet
- Added very basic unit tests for the jenkins1 recipe
- Created a shared ServerSpec test for testing basic jenkins functionality
- Include build-essential for CentOS 6 due to an upstream issue with the jenkins
  cookbook