### PR TITLE
Switch to using Jenkins API token instead of password

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -99,7 +99,7 @@ suites:
           jenkins:
             cookbook_uploader:
               user: <%= ENV['JENKINS_USER'] %>
-              pass: <%= ENV['JENKINS_PASS'] %>
+              api_token: <%= ENV['JENKINS_PASS'] %>
               trigger_token: <%= ENV['TRIGGER_TOKEN'] %>
       jenkins:
         master:
@@ -135,7 +135,7 @@ suites:
           jenkins:
             cookbook_uploader:
               user: <%= ENV['JENKINS_USER'] %>
-              pass: <%= ENV['JENKINS_PASS'] %>
+              api_token: <%= ENV['JENKINS_PASS'] %>
               trigger_token: <%= ENV['TRIGGER_TOKEN'] %>
       jenkins:
         master:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ default['osl-jenkins']['credentials']['git'] = []
 # user: (String)  If Jenkins has username/password security enabled (as opposed to being public and not requiring a
 #                 login), you must specify a Jenkins user that has permission to create jobs since the Jenkins cookbook
 #                 uses the Jenkins API locally to configure new jobs, and so needs credentials.
-# pass: (String)  The password associated with the above Jenkins user.
+# api_token (String) Jenkins user api token for authentication with Jenkins server.
 # trigger_token: (String) A random string that is used to allow GitHub to send pushes to Jenkins. Jenkins' job trigger
 #                 URLs are publicly accessible, so Jenkins will ignore POSTs to them unless the correct trigger_token is
 #                 specified. You can generate a random string easily with a command such as `pwgen -s 20 1`.
@@ -31,7 +31,7 @@ default['osl-jenkins']['credentials']['git'] = []
 # default['osl-jenkins']['credentials']['jenkins'] = {
 #   'cookbook_uploader' => {
 #     user: 'jenkins',
-#     pass: 'jenkins_password',
+#     api_token: 'jenkins_api_token',
 #     trigger_token: 'trigger_token'
 #   }
 # }

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -127,7 +127,7 @@ repo_names.each do |repo_name|
     jenkins_cred['trigger_token'],
     node['osl-jenkins']['cookbook_uploader']['github_insecure_hook'],
     jenkins_cred['user'],
-    jenkins_cred['password']
+    jenkins_cred['api_token']
   )
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,14 +39,5 @@ end
 shared_context 'cookbook_uploader' do
   before do
     allow_any_instance_of(Chef::Recipe).to receive(:set_up_github_push)
-    allow(Chef::EncryptedDataBagItem).to receive(:load).with('osl_jenkins', 'cookbook_uploader_secrets')
-      .and_return(
-        jenkins_private_key: 'private_key',
-        github_user: 'manatee',
-        github_token: 'github_token',
-        trigger_token: 'trigger_token',
-        jenkins_user: 'jenkins',
-        jenkins_api_token: 'jenkins_api_token'
-      )
   end
 end

--- a/spec/unit/recipes/cookbook_uploader_spec.rb
+++ b/spec/unit/recipes/cookbook_uploader_spec.rb
@@ -23,7 +23,7 @@ describe 'osl-jenkins::cookbook_uploader' do
           node.set['osl-jenkins']['credentials']['jenkins'] = {
             'cookbook_uploader' => {
               user: 'manatee',
-              pass: 'password',
+              api_token: 'api_token',
               trigger_token: 'trigger_token'
             }
           }


### PR DESCRIPTION
I neglected to notice that we had switched away from using the password to using
an API token in 5a6b4e051dcfd8e6684ae49a3020cdeca15cdf4f. This resolves that
issue.