### PR TITLE
Enable Octokit API caching

### DIFF
--- a/files/default/lib/bumpzone.rb
+++ b/files/default/lib/bumpzone.rb
@@ -2,6 +2,15 @@
 require 'git'
 require 'json'
 require 'octokit'
+require 'faraday-http-cache'
+
+# Github API caching
+stack = Faraday::RackBuilder.new do |builder|
+  builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
+  builder.use Octokit::Response::RaiseError
+  builder.adapter Faraday.default_adapter
+end
+Octokit.middleware = stack
 
 # Library to bump DNS zones
 class BumpZone

--- a/files/default/lib/github_comment.rb
+++ b/files/default/lib/github_comment.rb
@@ -2,6 +2,15 @@
 require 'git'
 require 'json'
 require 'octokit'
+require 'faraday-http-cache'
+
+# Github API caching
+stack = Faraday::RackBuilder.new do |builder|
+  builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
+  builder.use Octokit::Response::RaiseError
+  builder.adapter Faraday.default_adapter
+end
+Octokit.middleware = stack
 
 # Given a repo, Github PR ID, and message text, add that text to the PR as
 # a comment

--- a/libraries/github.rb
+++ b/libraries/github.rb
@@ -1,3 +1,15 @@
+if defined?(Faraday::HttpCache)
+  require 'faraday-http-cache'
+
+  # Github API caching
+  stack = Faraday::RackBuilder.new do |builder|
+    builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
+    builder.use Octokit::Response::RaiseError
+    builder.adapter Faraday.default_adapter
+  end
+  Octokit.middleware = stack
+end
+
 # Given a GitHub organization name and a GitHub API token with access to view
 # the repositories in that org, returns a list of all repo names in the org.
 #
@@ -6,7 +18,6 @@
 # @param org_name [String] Name of GitHub organization.
 def collect_github_repositories(github_token, org_name)
   require 'octokit'
-
   github = Octokit::Client.new(access_token: github_token)
   github.auto_paginate = true
 

--- a/recipes/bumpzone.rb
+++ b/recipes/bumpzone.rb
@@ -20,7 +20,7 @@ include_recipe 'osl-jenkins::master'
 bumpzone = node['osl-jenkins']['bumpzone']
 
 # Install necessary gems
-%w(git octokit).each do |g|
+%w(git octokit faraday-http-cache).each do |g|
   chef_gem g do # ~FC009
     compile_time true
   end

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -55,7 +55,7 @@ git_cred = secrets['git']['cookbook_uploader']
 jenkins_cred = secrets['jenkins']['cookbook_uploader']
 
 # Install necessary gems
-%w(git octokit).each do |g|
+%w(git octokit faraday-http-cache).each do |g|
   chef_gem g do # ~FC009
     compile_time true
   end

--- a/recipes/github_comment.rb
+++ b/recipes/github_comment.rb
@@ -20,7 +20,7 @@ include_recipe 'osl-jenkins::master'
 github_comment = node['osl-jenkins']['github_comment']
 
 # Install necessary gems
-%w(git octokit).each do |g|
+%w(git octokit faraday-http-cache).each do |g|
   chef_gem g do # ~FC009
     compile_time true
   end

--- a/spec/unit/recipes/cookbook_uploader_spec.rb
+++ b/spec/unit/recipes/cookbook_uploader_spec.rb
@@ -48,7 +48,7 @@ describe 'osl-jenkins::cookbook_uploader' do
           expect(chef_run).to install_jenkins_plugin(plugin).with(version: ver)
         end
       end
-      %w(git octokit).each do |g|
+      %w(git octokit faraday-http-cache).each do |g|
         it do
           expect(chef_run).to install_chef_gem(g).with(compile_time: true)
         end

--- a/templates/default/bump_environments.rb.erb
+++ b/templates/default/bump_environments.rb.erb
@@ -10,6 +10,15 @@ require 'git'
 require 'json'
 require 'octokit'
 require 'set'
+require 'faraday-http-cache'
+
+# Github API caching
+stack = Faraday::RackBuilder.new do |builder|
+  builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
+  builder.use Octokit::Response::RaiseError
+  builder.adapter Faraday.default_adapter
+end
+Octokit.middleware = stack
 
 # TODO: Validate input
 

--- a/templates/default/github_pr_comment_trigger.rb.erb
+++ b/templates/default/github_pr_comment_trigger.rb.erb
@@ -14,6 +14,7 @@
 require 'git'
 require 'json'
 require 'octokit'
+require 'faraday-http-cache'
 
 METADATA_FILE = 'metadata.rb'.freeze
 CHANGELOG_FILE = 'CHANGELOG.md'.freeze
@@ -26,6 +27,14 @@ LEVELS = {
 AUTHORIZED_USERS = <%= @authorized_users %>.freeze
 AUTHORIZED_ORGS = <%= @authorized_orgs %>.freeze
 AUTHORIZED_TEAMS = <%= @authorized_teams %>.freeze
+
+# Github API caching
+stack = Faraday::RackBuilder.new do |builder|
+  builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
+  builder.use Octokit::Response::RaiseError
+  builder.adapter Faraday.default_adapter
+end
+Octokit.middleware = stack
 
 # Given a GitHub client, a GitHub username, and a GitHub team (of the form
 # "$ORGNAME/$TEAMNAME"), returns whether the given user is a member of the


### PR DESCRIPTION
This enables caching for Github API calls based on upstream documentation [1].
This should improve some of the lookups we do and probably also minimize the
random errors we get likely due to API limiting from github.

[1] https://github.com/octokit/octokit.rb#caching