### PR TITLE
Update list of default environments the bump ~ command uses

### DIFF
--- a/recipes/jenkins1.rb
+++ b/recipes/jenkins1.rb
@@ -19,11 +19,12 @@ node.default['osl-jenkins']['cookbook_uploader'].tap do |conf|
   conf['authorized_teams'] = %w(osuosl-cookbooks/staff)
   conf['chef_repo'] = 'osuosl/chef-repo'
   conf['default_environments'] = %w(
-    production
-    workstation
-    openstack_production
-    openstack_staging
+    openstack_mitaka
+    phase_out_nginx
     phpbb
+    production
+    testing
+    workstation
   )
   conf['org'] = 'osuosl-cookbooks'
 end


### PR DESCRIPTION
Removing the old openstack environments as we don't want to bump anything there
anymore and replacing them with the openstack_mitaka. Adding testing and
phase_out_nginx since those should be safe to bump (usually).