### PR TITLE
Assign master node for bumpzone/checkzone jobs

### DIFF
--- a/templates/default/bumpzone.config.xml.erb
+++ b/templates/default/bumpzone.config.xml.erb
@@ -40,6 +40,7 @@
       </hudson.plugins.git.extensions.impl.LocalBranch>
     </extensions>
   </scm>
+  <assignedNode>master</assignedNode>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/templates/default/checkzone.config.xml.erb
+++ b/templates/default/checkzone.config.xml.erb
@@ -35,6 +35,7 @@
     <submoduleCfg class="list"/>
     <extensions/>
   </scm>
+  <assignedNode>master</assignedNode>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>


### PR DESCRIPTION
Without this, it doesn't work in production properly.