### PR TITLE
Install plugins all from one recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,13 +26,6 @@ suites:
             alfred:
               user: 'alfred'
               private_key: "-----BEGIN RSA PRIVATE KEY-----\nMIIBywIBAAJhAMSrk3a8XLZW0UdtDS49VdaPRskJtrCIPfJy9ZWMA5LyCob+e0DW\nRN33vA+x0wmw4hievTtpNDbntGpN+rnq5Xl/Nlpo+rxa+eLj3anU030gYYKFc0K0\nC7wu+EtZ6ZvKpQIDAQABAmA9cxKfTdl2C4hWVeeBZB627IuEcymG3PrmDy9Wq6nO\nNxw887SVHJ3l8OrsyHYVGBPwJXd2dfrFVwjdD6UeHXIqx2Lb9I1CzYVa7RkGL1ZU\nTAb1JdDf5vZFpELlkqczcp0CMQD2JfP/r55uRowVUs9+c7MN8J5Cg4YXDw6MQgpE\nE3+x92xM3TQzGM3PNeNpuby0fx8CMQDMiqsnoQQe8dEbAPetgBHZncA4TvS1w6KF\nq72HOwa2PW7DQXsiwuIN/wNhgALSMbsCMQCJJT5c8NnCMZZtbxVjLE3Qb4eOIb/9\naws9BLK5mW+llekGrp0d9yz8zdammrFUlBsCMF3qEZn5gVXf+/3lHNOp6Qg9OUPh\nZNSMRfQQHc6YmIVWgaPfTfVw+7AnddrvltwB/wIxAL+Q5ZXtglRrFFoYNdHplHb+\nBPgWsltlXXY1BmOEUWgAZLEs+tvSV8enIVlUSZ+Lxg==\n-----END RSA PRIVATE KEY-----"
-      certificate:
-        - snakeoil:
-            cert_path: "/etc/pki/tls"
-            cert_file: wildcard.pem
-            key_file: wildcard.key
-            chain_file: wildcard-bundle.crt
-            combined_file: true
 
   - name: haproxy
     encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
@@ -40,14 +33,6 @@ suites:
       - recipe[certificate::manage_by_attributes]
       - recipe[osl-jenkins::haproxy]
       - recipe[osl-haproxy::default]
-    attributes:
-      certificate:
-        - snakeoil:
-            cert_path: "/etc/pki/tls"
-            cert_file: wildcard.pem
-            key_file: wildcard.key
-            chain_file: wildcard-bundle.crt
-            combined_file: true
   - name: chef_backup
     run_list:
       - recipe[osl-jenkins::chef_backup]
@@ -116,13 +101,6 @@ suites:
       jenkins:
         master:
           listen_address: '0.0.0.0'
-      certificate:
-        - snakeoil:
-            cert_path: "/etc/pki/tls"
-            cert_file: wildcard.pem
-            key_file: wildcard.key
-            chain_file: wildcard-bundle.crt
-            combined_file: true
   # See documentation from cookbook-uploader suite on how to run this suite
   - name: jenkins1
     encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
@@ -152,13 +130,6 @@ suites:
       jenkins:
         master:
           listen_address: '0.0.0.0'
-      certificate:
-        - snakeoil:
-            cert_path: "/etc/pki/tls"
-            cert_file: wildcard.pem
-            key_file: wildcard.key
-            chain_file: wildcard-bundle.crt
-            combined_file: true
   - name: bumpzone
     encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
     run_list:
@@ -185,13 +156,6 @@ suites:
       jenkins:
         master:
           listen_address: '0.0.0.0'
-      certificate:
-        - snakeoil:
-            cert_path: "/etc/pki/tls"
-            cert_file: wildcard.pem
-            key_file: wildcard.key
-            chain_file: wildcard-bundle.crt
-            combined_file: true
   - name: github_comment
     run_list:
       - recipe[osl-jenkins::github_comment]
@@ -216,10 +180,3 @@ suites:
       jenkins:
         master:
           listen_address: '0.0.0.0'
-      certificate:
-        - snakeoil:
-            cert_path: "/etc/pki/tls"
-            cert_file: wildcard.pem
-            key_file: wildcard.key
-            chain_file: wildcard-bundle.crt
-            combined_file: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,14 @@ provisioner:
   name: chef_solo
   encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
   data_bags_path: test/integration/data_bags
+  attributes:
+    certificate:
+      - snakeoil:
+          cert_path: "/etc/pki/tls"
+          cert_file: wildcard.pem
+          key_file: wildcard.key
+          chain_file: wildcard-bundle.crt
+          combined_file: true
 
 suites:
   - name: default
@@ -54,8 +62,6 @@ suites:
   - name: plugins
     run_list:
       - recipe[osl-jenkins::master]
-      - recipe[jenkins::java]
-      - recipe[jenkins::master]
       - recipe[osl-jenkins::plugins]
   - name: ftp
     run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,4 +1,7 @@
 ---
+driver:
+  flavor_ref: 'm1.medium'
+
 provisioner:
   name: chef_solo
   encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret

--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -4,6 +4,10 @@
 #   plugin ->
 #     println ("${plugin.getShortName()}:${plugin.getVersion()}")
 # }
+default['osl-jenkins']['restart_plugins'] = %w(
+  credentials:2.1.13
+  ssh-credentials:1.13
+)
 default['osl-jenkins']['plugins'] = %w(
   ace-editor:1.1
   ant:1.2
@@ -14,7 +18,6 @@ default['osl-jenkins']['plugins'] = %w(
   build-token-root:1.4
   cloudbees-folder:6.0.3
   conditional-buildstep:1.3.1
-  credentials:2.1.13
   credentials-binding:1.11
   cvs:2.12
   display-url-api:1.1.1
@@ -66,7 +69,6 @@ default['osl-jenkins']['plugins'] = %w(
   scm-api:2.1.1
   script-security:1.27
   ssh-agent:1.15
-  ssh-credentials:1.13
   ssh-slaves:1.16
   structs:1.6
   subversion:2.5.7

--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -1,5 +1,89 @@
-default['osl-jenkins']['plugins'] = [
-  'build-token-root',
-  'credentials',
-  'credentials-binding'
-]
+# To generate this list, import the the following code into https://jenkins.osuosl.org/script and run it.
+#
+# Jenkins.instance.pluginManager.plugins.each{
+#   plugin ->
+#     println ("${plugin.getShortName()}:${plugin.getVersion()}")
+# }
+default['osl-jenkins']['plugins'] = %w(
+  ace-editor:1.1
+  ant:1.2
+  antisamy-markup-formatter:1.3
+  authentication-tokens:1.3
+  bouncycastle-api:2.16.1
+  branch-api:2.0.8
+  build-token-root:1.4
+  cloudbees-folder:6.0.3
+  conditional-buildstep:1.3.1
+  credentials:2.1.13
+  credentials-binding:1.11
+  cvs:2.12
+  display-url-api:1.1.1
+  docker-commons:1.6
+  docker-workflow:1.10
+  durable-task:1.13
+  external-monitor-job:1.4
+  ghprb:1.36.1
+  git:3.2.0
+  git-client:2.4.1
+  github:1.26.2
+  github-api:1.85
+  github-branch-source:2.0.5
+  github-oauth:0.22.3
+  github-organization-folder:1.6
+  gitlab-plugin:1.4.4
+  git-server:1.7
+  handlebars:1.1.1
+  icon-shim:2.0.3
+  instant-messaging:1.35
+  ircbot:2.27
+  javadoc:1.3
+  jquery-detached:1.2.1
+  junit:1.20
+  ldap:1.12
+  mailer:1.20
+  mapdb-api:1.0.6.0
+  matrix-auth:1.5
+  matrix-project:1.7.1
+  maven-plugin:2.12.1
+  momentjs:1.1.1
+  pam-auth:1.2
+  parameterized-trigger:2.33
+  pipeline-build-step:2.5
+  pipeline-github-lib:1.0
+  pipeline-graph-analysis:1.3
+  pipeline-input-step:2.5
+  pipeline-milestone-step:1.3.1
+  pipeline-model-api:1.1.2
+  pipeline-model-declarative-agent:1.1.1
+  pipeline-model-definition:1.1.2
+  pipeline-model-extensions:1.1.2
+  pipeline-rest-api:2.6
+  pipeline-stage-step:2.2
+  pipeline-stage-tags-metadata:1.1.2
+  pipeline-stage-view:2.6
+  plain-credentials:1.4
+  run-condition:1.0
+  scm-api:2.1.1
+  script-security:1.27
+  ssh-agent:1.15
+  ssh-credentials:1.12
+  ssh-slaves:1.16
+  structs:1.6
+  subversion:2.5.7
+  text-finder:1.10
+  token-macro:2.1
+  translation:1.12
+  windows-slaves:1.1
+  workflow-aggregator:2.5
+  workflow-api:2.12
+  workflow-basic-steps:2.4
+  workflow-cps:2.29
+  workflow-cps-global-lib:2.7
+  workflow-durable-task-step:2.10
+  workflow-job:2.10
+  workflow-multibranch:2.14
+  workflow-scm-step:2.4
+  workflow-step-api:2.9
+  workflow-support:2.14
+  ws-cleanup:0.28
+)

--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -24,7 +24,7 @@ default['osl-jenkins']['plugins'] = %w(
   external-monitor-job:1.4
   ghprb:1.36.1
   git:3.2.0
-  git-client:2.4.1
+  git-client:2.4.6
   github:1.26.2
   github-api:1.85
   github-branch-source:2.0.5
@@ -66,7 +66,7 @@ default['osl-jenkins']['plugins'] = %w(
   scm-api:2.1.1
   script-security:1.27
   ssh-agent:1.15
-  ssh-credentials:1.12
+  ssh-credentials:1.13
   ssh-slaves:1.16
   structs:1.6
   subversion:2.5.7

--- a/recipes/bumpzone.rb
+++ b/recipes/bumpzone.rb
@@ -51,23 +51,6 @@ end
   end
 end
 
-{
-  'mailer' => '1.20',
-  'token-macro' => '2.1',
-  'git' => '3.2.0',
-  'github' => '1.26.2',
-  'matrix-project' => '1.7.1',
-  'build-token-root' => '1.4',
-  'parameterized-trigger' => '2.33',
-  'text-finder' => '1.10',
-  'script-security' => '1.27'
-}.each do |p, v|
-  jenkins_plugin p do
-    version v
-    notifies :execute, 'jenkins_command[safe-restart]'
-  end
-end
-
 package 'bind'
 
 secrets = credential_secrets

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -19,29 +19,6 @@
 
 include_recipe 'osl-jenkins::master'
 
-# Lock version per plugin so it doesn't install latest on every run.
-# git and github: for git
-# build-token-root: for triggering from Github PRs
-# parameterized-trigger: for triggering other jobs (e.g. the environment-bumper
-#   job) with parameters
-# text-finder: for marking unstable builds (used in this case to mark builds
-#   where no action was taken)
-{
-  'mailer' => '1.20',
-  'token-macro' => '2.1',
-  'git' => '3.2.0',
-  'github' => '1.26.2',
-  'build-token-root' => '1.4',
-  'parameterized-trigger' => '2.33',
-  'text-finder' => '1.10',
-  'script-security' => '1.27'
-}.each do |p, v|
-  jenkins_plugin p do
-    version v
-    notifies :execute, 'jenkins_command[safe-restart]'
-  end
-end
-
 org_name = node['osl-jenkins']['cookbook_uploader']['org']
 chef_repo = node['osl-jenkins']['cookbook_uploader']['chef_repo']
 

--- a/recipes/github_comment.rb
+++ b/recipes/github_comment.rb
@@ -49,16 +49,6 @@ cookbook_file ::File.join(github_comment['lib_path'], 'github_comment.rb') do
   mode 0440
 end
 
-{
-  'github' => '1.26.2',
-  'ghprb' => '1.36.1'
-}.each do |p, v|
-  jenkins_plugin p do
-    version v
-    notifies :restart, 'service[jenkins]'
-  end
-end
-
 github_comment_xml = ::File.join(Chef::Config[:file_cache_path], 'github_comment', 'config.xml')
 
 directory ::File.dirname(github_comment_xml) do

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -71,20 +71,7 @@ jenkins_command 'safe-restart' do
   action :nothing
 end
 
-{
-  'credentials' => '2.1.13',
-  'credentials-binding' => '1.11'
-}.each do |p, v|
-  jenkins_plugin p do
-    version v
-    notifies :execute, 'jenkins_command[safe-restart]'
-  end
-end
-
-jenkins_plugin 'ssh-credentials' do
-  version '1.12'
-  notifies :execute, 'jenkins_command[safe-restart]', :immediately
-end
+include_recipe 'osl-jenkins::plugins'
 
 secrets = credential_secrets
 

--- a/recipes/plugins.rb
+++ b/recipes/plugins.rb
@@ -15,7 +15,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
+# Install plugins that need to be loaded later for Chef to function and require a Jenkins restart immediately
+node['osl-jenkins']['restart_plugins'].each do |plugins_version|
+  p, v = plugins_version.split(':')
+  jenkins_plugin p do
+    version v
+    install_deps false
+    notifies :execute, 'jenkins_command[safe-restart]', :immediately
+  end
+end
+
+# Install plugins that can allow for Jenkins restarts later
 node['osl-jenkins']['plugins'].each do |plugins_version|
   p, v = plugins_version.split(':')
   jenkins_plugin p do

--- a/recipes/plugins.rb
+++ b/recipes/plugins.rb
@@ -16,9 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-node['osl-jenkins']['plugins'].each do |plugin|
-  jenkins_plugin plugin do
-    notifies :restart, 'service[jenkins]'
+node['osl-jenkins']['plugins'].each do |plugins_version|
+  p, v = plugins_version.split(':')
+  jenkins_plugin p do
+    version v
+    install_deps false
+    notifies :execute, 'jenkins_command[safe-restart]'
   end
 end

--- a/spec/unit/recipes/bumpzone_spec.rb
+++ b/spec/unit/recipes/bumpzone_spec.rb
@@ -24,12 +24,6 @@ describe 'osl-jenkins::bumpzone' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
-      it do
-        expect(chef_run).to install_jenkins_plugin('matrix-project').with(version: '1.7.1')
-      end
-      it do
-        expect(chef_run.jenkins_plugin('matrix-project')).to notify('jenkins_command[safe-restart]')
-      end
       %w(/var/lib/jenkins/bin /var/lib/jenkins/lib).each do |d|
         it do
           expect(chef_run).to create_directory(d).with(recursive: true)

--- a/spec/unit/recipes/cookbook_uploader_spec.rb
+++ b/spec/unit/recipes/cookbook_uploader_spec.rb
@@ -34,20 +34,6 @@ describe 'osl-jenkins::cookbook_uploader' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
-      {
-        'mailer' => '1.20',
-        'token-macro' => '2.1',
-        'git' => '3.2.0',
-        'github' => '1.26.2',
-        'build-token-root' => '1.4',
-        'parameterized-trigger' => '2.33',
-        'text-finder' => '1.10',
-        'script-security' => '1.27'
-      }.each do |plugin, ver|
-        it do
-          expect(chef_run).to install_jenkins_plugin(plugin).with(version: ver)
-        end
-      end
       %w(git octokit faraday-http-cache).each do |g|
         it do
           expect(chef_run).to install_chef_gem(g).with(compile_time: true)

--- a/spec/unit/recipes/github_comment_spec.rb
+++ b/spec/unit/recipes/github_comment_spec.rb
@@ -52,14 +52,6 @@ describe 'osl-jenkins::github_comment' do
           expect(chef_run).to install_chef_gem(g).with(compile_time: true)
         end
       end
-      {
-        'github' => '1.26.2',
-        'ghprb' => '1.36.1'
-      }.each do |plugin, ver|
-        it do
-          expect(chef_run).to install_jenkins_plugin(plugin).with(version: ver)
-        end
-      end
 
       it 'creates the directory' do
         expect(chef_run).to create_directory('/var/chef/cache/github_comment').with(recursive: true)

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -30,21 +30,6 @@ describe 'osl-jenkins::master' do
       it do
         expect(chef_run).to_not execute_jenkins_command('safe-restart')
       end
-      {
-        'credentials' => '2.1.13',
-        'credentials-binding' => '1.11',
-        'ssh-credentials' => '1.12'
-      }.each do |plugin, ver|
-        it do
-          expect(chef_run).to install_jenkins_plugin(plugin).with(version: ver)
-        end
-        it do
-          expect(chef_run.jenkins_plugin(plugin)).to notify('jenkins_command[safe-restart]')
-        end
-      end
-      it do
-        expect(chef_run.jenkins_plugin('ssh-credentials')).to notify('jenkins_command[safe-restart]').immediately
-      end
       context 'set secrets in attribute' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p) do |node|

--- a/spec/unit/recipes/plugins_spec.rb
+++ b/spec/unit/recipes/plugins_spec.rb
@@ -11,6 +11,21 @@ describe 'osl-jenkins::plugins' do
         expect { chef_run }.to_not raise_error
       end
       %w(
+        credentials:2.1.13
+        ssh-credentials:1.13
+      ).each do |plugins_version|
+        plugin, version = plugins_version.split(':')
+        it do
+          expect(chef_run).to install_jenkins_plugin(plugin).with(
+            version: version,
+            install_deps: false
+          )
+        end
+        it do
+          expect(chef_run.jenkins_plugin(plugin)).to notify('jenkins_command[safe-restart]').to(:execute).immediately
+        end
+      end
+      %w(
         ace-editor:1.1
         ant:1.2
         antisamy-markup-formatter:1.3
@@ -20,7 +35,6 @@ describe 'osl-jenkins::plugins' do
         build-token-root:1.4
         cloudbees-folder:6.0.3
         conditional-buildstep:1.3.1
-        credentials:2.1.13
         credentials-binding:1.11
         cvs:2.12
         display-url-api:1.1.1
@@ -72,7 +86,6 @@ describe 'osl-jenkins::plugins' do
         scm-api:2.1.1
         script-security:1.27
         ssh-agent:1.15
-        ssh-credentials:1.13
         ssh-slaves:1.16
         structs:1.6
         subversion:2.5.7

--- a/spec/unit/recipes/plugins_spec.rb
+++ b/spec/unit/recipes/plugins_spec.rb
@@ -30,7 +30,7 @@ describe 'osl-jenkins::plugins' do
         external-monitor-job:1.4
         ghprb:1.36.1
         git:3.2.0
-        git-client:2.4.1
+        git-client:2.4.6
         github:1.26.2
         github-api:1.85
         github-branch-source:2.0.5
@@ -72,7 +72,7 @@ describe 'osl-jenkins::plugins' do
         scm-api:2.1.1
         script-security:1.27
         ssh-agent:1.15
-        ssh-credentials:1.12
+        ssh-credentials:1.13
         ssh-slaves:1.16
         structs:1.6
         subversion:2.5.7

--- a/spec/unit/recipes/plugins_spec.rb
+++ b/spec/unit/recipes/plugins_spec.rb
@@ -1,0 +1,109 @@
+require_relative '../../spec_helper'
+
+describe 'osl-jenkins::plugins' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge('osl-jenkins::master', described_recipe)
+      end
+      include_context 'common_stubs'
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      %w(
+        ace-editor:1.1
+        ant:1.2
+        antisamy-markup-formatter:1.3
+        authentication-tokens:1.3
+        bouncycastle-api:2.16.1
+        branch-api:2.0.8
+        build-token-root:1.4
+        cloudbees-folder:6.0.3
+        conditional-buildstep:1.3.1
+        credentials:2.1.13
+        credentials-binding:1.11
+        cvs:2.12
+        display-url-api:1.1.1
+        docker-commons:1.6
+        docker-workflow:1.10
+        durable-task:1.13
+        external-monitor-job:1.4
+        ghprb:1.36.1
+        git:3.2.0
+        git-client:2.4.1
+        github:1.26.2
+        github-api:1.85
+        github-branch-source:2.0.5
+        github-oauth:0.22.3
+        github-organization-folder:1.6
+        gitlab-plugin:1.4.4
+        git-server:1.7
+        handlebars:1.1.1
+        icon-shim:2.0.3
+        instant-messaging:1.35
+        ircbot:2.27
+        javadoc:1.3
+        jquery-detached:1.2.1
+        junit:1.20
+        ldap:1.12
+        mailer:1.20
+        mapdb-api:1.0.6.0
+        matrix-auth:1.5
+        matrix-project:1.7.1
+        maven-plugin:2.12.1
+        momentjs:1.1.1
+        pam-auth:1.2
+        parameterized-trigger:2.33
+        pipeline-build-step:2.5
+        pipeline-github-lib:1.0
+        pipeline-graph-analysis:1.3
+        pipeline-input-step:2.5
+        pipeline-milestone-step:1.3.1
+        pipeline-model-api:1.1.2
+        pipeline-model-declarative-agent:1.1.1
+        pipeline-model-definition:1.1.2
+        pipeline-model-extensions:1.1.2
+        pipeline-rest-api:2.6
+        pipeline-stage-step:2.2
+        pipeline-stage-tags-metadata:1.1.2
+        pipeline-stage-view:2.6
+        plain-credentials:1.4
+        run-condition:1.0
+        scm-api:2.1.1
+        script-security:1.27
+        ssh-agent:1.15
+        ssh-credentials:1.12
+        ssh-slaves:1.16
+        structs:1.6
+        subversion:2.5.7
+        text-finder:1.10
+        token-macro:2.1
+        translation:1.12
+        windows-slaves:1.1
+        workflow-aggregator:2.5
+        workflow-api:2.12
+        workflow-basic-steps:2.4
+        workflow-cps:2.29
+        workflow-cps-global-lib:2.7
+        workflow-durable-task-step:2.10
+        workflow-job:2.10
+        workflow-multibranch:2.14
+        workflow-scm-step:2.4
+        workflow-step-api:2.9
+        workflow-support:2.14
+        ws-cleanup:0.28
+      ).each do |plugins_version|
+        plugin, version = plugins_version.split(':')
+        it do
+          expect(chef_run).to install_jenkins_plugin(plugin).with(
+            version: version,
+            install_deps: false
+          )
+        end
+        it do
+          expect(chef_run.jenkins_plugin(plugin)).to notify('jenkins_command[safe-restart]')
+        end
+      end
+    end
+  end
+end

--- a/test/integration/plugins/serverspec/plugins_spec.rb
+++ b/test/integration/plugins/serverspec/plugins_spec.rb
@@ -2,14 +2,95 @@ require 'serverspec'
 
 set :backend, :exec
 
-describe file('/var/lib/jenkins/plugins/build-token-root.jpi') do
-  it { should be_file }
+describe file('/var/log/jenkins/jenkins.log') do
+  its(:content) { should_not match(/SEVERE: Failed Loading plugin/) }
 end
 
-describe file('/var/lib/jenkins/plugins/credentials.jpi') do
-  it { should be_file }
-end
-
-describe file('/var/lib/jenkins/plugins/credentials-binding.jpi') do
-  it { should be_file }
+describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localhost:8080/ list-plugins') do
+  %w(
+    ace-editor:1.1
+    ant:1.2
+    antisamy-markup-formatter:1.3
+    authentication-tokens:1.3
+    bouncycastle-api:2.16.1
+    branch-api:2.0.8
+    build-token-root:1.4
+    cloudbees-folder:6.0.3
+    conditional-buildstep:1.3.1
+    credentials:2.1.13
+    credentials-binding:1.11
+    cvs:2.12
+    display-url-api:1.1.1
+    docker-commons:1.6
+    docker-workflow:1.10
+    durable-task:1.13
+    external-monitor-job:1.4
+    ghprb:1.36.1
+    git:3.2.0
+    git-client:2.4.1
+    github:1.26.2
+    github-api:1.85
+    github-branch-source:2.0.5
+    github-oauth:0.22.3
+    github-organization-folder:1.6
+    gitlab-plugin:1.4.4
+    git-server:1.7
+    handlebars:1.1.1
+    icon-shim:2.0.3
+    instant-messaging:1.35
+    ircbot:2.27
+    javadoc:1.3
+    jquery-detached:1.2.1
+    junit:1.20
+    ldap:1.12
+    mailer:1.20
+    mapdb-api:1.0.6.0
+    matrix-auth:1.5
+    matrix-project:1.7.1
+    maven-plugin:2.12.1
+    momentjs:1.1.1
+    pam-auth:1.2
+    parameterized-trigger:2.33
+    pipeline-build-step:2.5
+    pipeline-github-lib:1.0
+    pipeline-graph-analysis:1.3
+    pipeline-input-step:2.5
+    pipeline-milestone-step:1.3.1
+    pipeline-model-api:1.1.2
+    pipeline-model-declarative-agent:1.1.1
+    pipeline-model-definition:1.1.2
+    pipeline-model-extensions:1.1.2
+    pipeline-rest-api:2.6
+    pipeline-stage-step:2.2
+    pipeline-stage-tags-metadata:1.1.2
+    pipeline-stage-view:2.6
+    plain-credentials:1.4
+    run-condition:1.0
+    scm-api:2.1.1
+    script-security:1.27
+    ssh-agent:1.15
+    ssh-credentials:1.12
+    ssh-slaves:1.16
+    structs:1.6
+    subversion:2.5.7
+    text-finder:1.10
+    token-macro:2.1
+    translation:1.12
+    windows-slaves:1.1
+    workflow-aggregator:2.5
+    workflow-api:2.12
+    workflow-basic-steps:2.4
+    workflow-cps:2.29
+    workflow-cps-global-lib:2.7
+    workflow-durable-task-step:2.10
+    workflow-job:2.10
+    workflow-multibranch:2.14
+    workflow-scm-step:2.4
+    workflow-step-api:2.9
+    workflow-support:2.14
+    ws-cleanup:0.28
+  ).each do |plugins_version|
+    plugin, version = plugins_version.split(':')
+    its(:stdout) { should match(/^#{plugin}.*#{version}[\s\(]?/) }
+  end
 end

--- a/test/integration/plugins/serverspec/plugins_spec.rb
+++ b/test/integration/plugins/serverspec/plugins_spec.rb
@@ -27,7 +27,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     external-monitor-job:1.4
     ghprb:1.36.1
     git:3.2.0
-    git-client:2.4.1
+    git-client:2.4.6
     github:1.26.2
     github-api:1.85
     github-branch-source:2.0.5
@@ -69,7 +69,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     scm-api:2.1.1
     script-security:1.27
     ssh-agent:1.15
-    ssh-credentials:1.12
+    ssh-credentials:1.13
     ssh-slaves:1.16
     structs:1.6
     subversion:2.5.7


### PR DESCRIPTION
This pulls in all plugin installation to one place. It also replicates the
plugins that are installed on the production jenkins master. To work around the
issues described in chef-cookbooks/jenkins#534, we default to install without
plugin dependencies and directly install the exact version of every plugin we
need.

In addition:
- Remove extraneous attributes from test-kitchen
- Update git-client due to security issue