### PR TITLE
add missing 'htdocs'

### DIFF
--- a/recipes/site_pr_builder.rb
+++ b/recipes/site_pr_builder.rb
@@ -24,7 +24,7 @@ site_pr_builder['sites_to_build'].each do |site, org|
   job_name = "#{site}_pr_builder"
   repo = "#{org}/#{site}"
   github_url = "https://github.com/#{repo}"
-  rsync_target = "/var/www/staging.osuosl.org/#{site}-$ghprbPullId"
+  rsync_target = "/var/www/staging.osuosl.org/htdocs/#{site}-$ghprbPullId"
   site_url = "http://#{site}-$ghprbPullId.staging.osuosl.org"
 
   site_pr_builder_xml = ::File.join(Chef::Config[:file_cache_path], job_name, 'config.xml')


### PR DESCRIPTION
Looks like the 'htdocs' component of the build path got lost somewhere, resulting in the site being in the wrong place.