### PR TITLE
Add recipe for power-ci

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -247,6 +247,5 @@ suites:
         master:
           listen_address: '0.0.0.0'
   - name: powerci 
-    encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
     run_list:
       - recipe[osl-jenkins::powerci]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -250,11 +250,3 @@ suites:
     encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
     run_list:
       - recipe[osl-jenkins::powerci]
-    attributes:
-      certificate:
-        - snakeoil:
-            cert_path: "/etc/pki/tls"
-            cert_file: power-ci.pem
-            key_file: power-ci.key
-            chain_file: power-ci-bundle.crt
-            combined_file: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -246,3 +246,15 @@ suites:
       jenkins:
         master:
           listen_address: '0.0.0.0'
+  - name: powerci 
+    encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
+    run_list:
+      - recipe[osl-jenkins::powerci]
+    attributes:
+      certificate:
+        - snakeoil:
+            cert_path: "/etc/pki/tls"
+            cert_file: power-ci.pem
+            key_file: power-ci.key
+            chain_file: power-ci-bundle.crt
+            combined_file: true

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -1,0 +1,165 @@
+#
+# Cookbook Name:: osl-jenkins
+# Recipe:: powerci
+#
+# Copyright 2015, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Don't automatically update jenkins
+node.override['yum-cron']['yum_parameter'] = '-x jenkins'
+
+node.default['jenkins']['master']['version'] = '2.46.3-1.1'
+node.default['jenkins']['master']['listen_address'] = '127.0.0.1'
+
+node.default['java']['jdk_version'] = '8'
+
+# Manually set the jenkins java attribute to stop jenkins being restarted
+# every chef run due to logic in
+# https://github.com/chef-cookbooks/jenkins/blob/master/attributes/default.rb#L45-L53
+node.set['jenkins']['java'] = 'java'
+
+node.default['certificate'] = [{
+  'power-ci' => {
+    'cert_file' => 'power-ci.pem',
+    'key_file' => 'power-ci.key',
+    'chain_file' => 'power-ci-bundle.crt',
+    'combined_file' => true
+  }
+}]
+
+include_recipe 'java'
+include_recipe 'jenkins::master'
+include_recipe 'certificate::manage_by_attributes'
+
+# haproxy settings
+node.default['haproxy']['enable_ssl'] = true
+
+node.default['haproxy']['frontend_max_connections'] = '2000' \
+  "\n  redirect scheme https if !{ ssl_fc }"
+
+node.default['haproxy']['ssl_incoming_port'] = \
+  '443 ssl crt /etc/pki/tls/power-ci.pem ' \
+  'ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:' \
+  'ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS no-sslv3'
+
+node.default['haproxy']['members'] = [
+  {
+    'hostname' => 'power-ci',
+    'ipaddress' => '127.0.0.1',
+    'port' => '8080'
+  }
+]
+include_recipe 'osl-haproxy::default'
+
+if platform_family?('rhel')
+  if node['platform_version'].to_i <= 6
+    # CentOS 6 packages Git 1.7.1, but we need at least Git 1.7.9 for the
+    # .git-credentials file to work (needed for the cookbook_uploader recipe),
+    # and the Jenkins git plugin recommends 1.8.x. So we use 1.8.5.5, the
+    # latest 1.8.x.
+    node.set['git']['version'] = '1.8.5.5'
+    node.set['git']['checksum'] = '106b480e2b3ae8b02e5b6b099d7a4049' \
+                                  'f2b1128659ac81f317267d2ed134679f'
+    include_recipe 'build-essential'
+    include_recipe 'git::source'
+
+    # Also create a symlink for when /usr/local/bin isn't in PATH.
+    link '/usr/bin/git' do
+      to '/usr/local/bin/git'
+    end
+  else
+    # For CentOS 7 and up, the packaged version is new enough.
+    include_recipe 'git::package'
+  end
+end
+
+jenkins_command 'safe-restart' do
+  action :nothing
+end
+
+node.default['osl-jenkins']['restart_plugins'] = %w(
+  credentials:2.1.13
+  ssh-credentials:1.13
+)
+node.default['osl-jenkins']['plugins'] = %w(
+  docker-commons:1.6
+  ssh-slaves:1.17
+  resource-disposer:0.6
+  pipeline-model-extensions:1.1.3
+  github:1.27.0
+  structs:1.6
+  emailext-template:1.0
+  git:3.3.0
+  pipeline-stage-tags-metadata:1.1.3
+  workflow-scm-step:2.4
+  github-api:1.85
+  workflow-cps-global-lib:2.8
+  openstack-cloud:2.22
+  cloudbees-folder:6.0.3
+  junit:1.20
+  bouncycastle-api:2.16.1
+  display-url-api:2.0
+  matrix-project:1.10
+  config-file-provider:2.15.7
+  handlebars:1.1.1
+  credentials-binding:1.11
+  workflow-cps:2.30
+  workflow-job:2.10
+  email-ext:2.57.2
+  pipeline-milestone-step:1.3.1
+  icon-shim:2.0.3
+  authentication-tokens:1.3
+  pipeline-rest-api:2.6
+  docker-build-publish:1.3.2
+  git-client:2.4.5
+  jquery-detached:1.2.1
+  pipeline-input-step:2.7
+  momentjs:1.1.1
+  workflow-support:2.14
+  pipeline-build-step:2.5
+  yet-another-docker-plugin:0.1.0-rc37
+  matrix-auth:1.5
+  workflow-multibranch:2.14
+  branch-api:2.0.8
+  embeddable-build-status:1.9
+  token-macro:2.1
+  workflow-step-api:2.9
+  build-monitor-plugin:1.11+build.201701152243
+  pipeline-multibranch-defaults:1.1
+  pipeline-model-declarative-agent:1.1.1
+  ace-editor:1.1
+  docker-workflow:1.10
+  workflow-durable-task-step:2.11
+  workflow-api:2.13
+  github-branch-source:2.0.5
+  docker-plugin:0.16.2
+  pipeline-model-definition:1.1.3
+  workflow-basic-steps:2.4
+  mailer:1.20
+  pipeline-model-api:1.1.3
+  pipeline-stage-step:2.2
+  durable-task:1.13
+  scm-api:2.1.1
+  cloud-stats:0.11
+  plain-credentials:1.4
+  github-oauth:0.27
+  pipeline-graph-analysis:1.3
+  script-security:1.27
+  workflow-aggregator:2.5
+  job-restrictions:0.6
+  pipeline-stage-view:2.6
+  git-server:1.7
+)
+include_recipe 'osl-jenkins::plugins'

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -17,18 +17,6 @@
 # limitations under the License.
 #
 
-node.override['haproxy']['members'] = [
-  {
-    'hostname' => 'power-ci',
-    'ipaddress' => '127.0.0.1',
-    'port' => '8080'
-  }
-]
-
-node.default['osl-jenkins']['restart_plugins'] = %w(
-  credentials:2.1.13
-  ssh-credentials:1.13
-)
 node.default['osl-jenkins']['plugins'] = %w(
   docker-commons:1.6
   ssh-slaves:1.17

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../spec_helper'
+
+describe 'osl-jenkins::powerci' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      include_context 'common_stubs'
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run).to install_package('jenkins').with(version: '2.46.3-1.1')
+      end
+      case p
+      when CENTOS_6_OPTS
+        it do
+          expect(chef_run).to create_link('/usr/bin/git').with(to: '/usr/local/bin/git')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -10,13 +10,28 @@ describe 'osl-jenkins::powerci' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
-      it do
-        expect(chef_run).to install_package('jenkins').with(version: '2.46.3-1.1')
-      end
-      case p
-      when CENTOS_6_OPTS
+      %w(
+        build-monitor-plugin:1.11+build.201701152243
+        docker-commons:1.6
+        docker-plugin:0.16.2
+        docker-build-publish:1.3.2
+        embeddable-build-status:1.9
+        git-client:2.4.5
+        github-api:1.85
+        github-oauth:0.27
+        job-restrictions:0.6
+        matrix-project:1.10
+        yet-another-docker-plugin:0.1.0-rc37
+      ).each do |plugins_version|
+        plugin, version = plugins_version.split(':')
         it do
-          expect(chef_run).to create_link('/usr/bin/git').with(to: '/usr/local/bin/git')
+          expect(chef_run).to install_jenkins_plugin(plugin).with(
+            version: version,
+            install_deps: false
+          )
+        end
+        it do
+          expect(chef_run.jenkins_plugin(plugin)).to notify('jenkins_command[safe-restart]')
         end
       end
     end

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -12,15 +12,22 @@ describe 'osl-jenkins::powerci' do
       end
       %w(
         build-monitor-plugin:1.11+build.201701152243
+        cloud-stats:0.11
+        config-file-provider:2.15.7
         docker-commons:1.6
         docker-plugin:0.16.2
         docker-build-publish:1.3.2
+        email-ext:2.57.2
+        emailext-template:1.0
         embeddable-build-status:1.9
         git-client:2.4.5
         github-api:1.85
         github-oauth:0.27
         job-restrictions:0.6
         matrix-project:1.10
+        openstack-cloud:2.22
+        pipeline-multibranch-defaults:1.1
+        resource-disposer:0.6
         yet-another-docker-plugin:0.1.0-rc37
       ).each do |plugins_version|
         plugin, version = plugins_version.split(':')

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 set :backend, :exec
 
-describe service('haproxy') do
-  it { should be_running }
-end
-
 describe 'powerci' do
   it_behaves_like 'jenkins_server'
 end

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+set :backend, :exec
+
+describe service('haproxy') do
+  it { should be_running }
+end
+
+describe 'powerci' do
+  it_behaves_like 'jenkins_server'
+end
+
+describe file('/var/log/jenkins/jenkins.log') do
+  its(:content) { should_not match(/SEVERE: Failed Loading plugin/) }
+end
+
+describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localhost:8080/ list-plugins') do
+  %w(
+    docker-commons:1.6
+    ssh-slaves:1.17
+    resource-disposer:0.6
+    pipeline-model-extensions:1.1.3
+    github:1.27.0
+    structs:1.6
+    emailext-template:1.0
+    git:3.3.0
+    pipeline-stage-tags-metadata:1.1.3
+    workflow-scm-step:2.4
+    github-api:1.85
+    workflow-cps-global-lib:2.8
+    openstack-cloud:2.22
+    cloudbees-folder:6.0.3
+    junit:1.20
+    bouncycastle-api:2.16.1
+    display-url-api:2.0
+    matrix-project:1.10
+    config-file-provider:2.15.7
+    handlebars:1.1.1
+    credentials-binding:1.11
+    workflow-cps:2.30
+    workflow-job:2.10
+    email-ext:2.57.2
+    pipeline-milestone-step:1.3.1
+    icon-shim:2.0.3
+    authentication-tokens:1.3
+    pipeline-rest-api:2.6
+    docker-build-publish:1.3.2
+    git-client:2.4.5
+    jquery-detached:1.2.1
+    pipeline-input-step:2.7
+    momentjs:1.1.1
+    ssh-credentials:1.13
+    workflow-support:2.14
+    yet-another-docker-plugin:0.1.0-rc37
+    pipeline-build-step:2.5
+    matrix-auth:1.5
+    workflow-multibranch:2.14
+    branch-api:2.0.8
+    embeddable-build-status:1.9
+    token-macro:2.1
+    workflow-step-api:2.9
+    build-monitor-plugin:1.11\+build.201701152243
+    pipeline-multibranch-defaults:1.1
+    pipeline-model-declarative-agent:1.1.1
+    ace-editor:1.1
+    docker-workflow:1.10
+    workflow-durable-task-step:2.11
+    workflow-api:2.13
+    github-branch-source:2.0.5
+    docker-plugin:0.16.2
+    pipeline-model-definition:1.1.3
+    workflow-basic-steps:2.4
+    mailer:1.20
+    credentials:2.1.13
+    pipeline-model-api:1.1.3
+    pipeline-stage-step:2.2
+    durable-task:1.13
+    scm-api:2.1.1
+    cloud-stats:0.11
+    plain-credentials:1.4
+    github-oauth:0.27
+    pipeline-graph-analysis:1.3
+    script-security:1.27
+    workflow-aggregator:2.5
+    job-restrictions:0.6
+    pipeline-stage-view:2.6
+    git-server:1.7
+  ).each do |plugins_version|
+    plugin, version = plugins_version.split(':')
+    its(:stdout) { should match(/^#{plugin}.*#{version}[\s\(]?/) }
+  end
+end


### PR DESCRIPTION
Initial work for power-ci.o.o. Installs Jenkins, Jenkins plugins, and haproxy. 

The list of Jenkins plugins is taken from https://power-ci.osuosl.org/jenkins/

Because of a delay when Jenkins is restarting, kitchen test will most likely fail. Running kitchen verify again after the failure will usually work. 