### PR TITLE
remove docs builder until fixed

### DIFF
--- a/attributes/site_pr_builder.rb
+++ b/attributes/site_pr_builder.rb
@@ -5,8 +5,7 @@ default['osl-jenkins']['site_pr_builder'] = {
     'beaver-barcamp-pelican' => 'osuosl',
     'cass-pelican' => 'osu-cass',
     'osuosl-pelican' => 'osuosl',
-    'wiki' => 'osuosl',
-    'docs' => 'osuosl'
+    'wiki' => 'osuosl'
   },
   'credentials' => {
     'trigger_token' => nil,

--- a/spec/unit/recipes/site_pr_builder_spec.rb
+++ b/spec/unit/recipes/site_pr_builder_spec.rb
@@ -27,7 +27,7 @@ describe 'osl-jenkins::site_pr_builder' do
       end
 
       %w(beaver-barcamp-pelican_pr_builder osuosl-pelican_pr_builder
-         cass-pelican_pr_builder wiki_pr_builder docs_pr_builder).each do |job|
+         cass-pelican_pr_builder wiki_pr_builder).each do |job|
         it do
           expect(chef_run).to create_directory("/var/chef/cache/#{job}").with(recursive: true)
         end

--- a/test/integration/site_pr_builder/serverspec/site_pr_builder_spec.rb
+++ b/test/integration/site_pr_builder/serverspec/site_pr_builder_spec.rb
@@ -8,7 +8,7 @@ describe 'site_pr_builder' do
 end
 
 sites = %w(beaver-barcamp-pelican_pr_builder cass-pelican_pr_builder
-           osuosl-pelican_pr_builder wiki_pr_builder docs_pr_builder)
+           osuosl-pelican_pr_builder wiki_pr_builder)
 
 sites.each do |job|
   describe command("curl -k https://127.0.0.1/job/#{job}/ -o /dev/null -v 2>&1") do


### PR DESCRIPTION
Docs build is broken, most likely due to docs being a private repo. This PR removes the docs builder job from chef until we figure out how to fix.