### PR TITLE
Add jenkins_scripts for Docker cloud, OpenStack Cloud, GitHub Oauth

### DIFF
--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -67,9 +67,9 @@ node.default['osl-jenkins']['restart_plugins'] = %w(
   github-branch-source:2.0.5
   github-oauth:0.27
   icon-shim:2.0.3
-  matrix-auth:1.5
   authentication-tokens:1.3
-
+  embeddable-build-status:1.9
+  matrix-auth:1.5
 )
 
 node.default['osl-jenkins']['plugins'] = %w(
@@ -92,7 +92,6 @@ node.default['osl-jenkins']['plugins'] = %w(
   momentjs:1.1.1
   pipeline-build-step:2.5
   yet-another-docker-plugin:0.1.0-rc37
-  embeddable-build-status:1.9
   build-monitor-plugin:1.11+build.201701152243
   pipeline-multibranch-defaults:1.1
   pipeline-model-declarative-agent:1.1.1
@@ -276,6 +275,7 @@ jenkins_script 'Add GitHub OAuth config' do
       "hudson.model.Computer.Create",
       "hudson.model.Computer.Delete",
       "hudson.model.Computer.Disconnect",
+      "hudson.model.Computer.Provision",
       "hudson.model.Hudson.Administer",
       "hudson.model.Hudson.Read",
       "hudson.model.Item.Build",
@@ -284,15 +284,18 @@ jenkins_script 'Add GitHub OAuth config' do
       "hudson.model.Item.Create",
       "hudson.model.Item.Delete",
       "hudson.model.Item.Discover",
+      "hudson.model.Item.Move",
       "hudson.model.Item.Read",
       "hudson.model.Item.ViewStatus",
       "hudson.model.Item.Workspace",
       "hudson.model.Run.Delete",
+      "hudson.model.Run.Replay",
       "hudson.model.Run.Update",
       "hudson.model.View.Configure",
       "hudson.model.View.Create",
       "hudson.model.View.Delete",
-      "hudson.model.View.Read"
+      "hudson.model.View.Read",
+      "hudson.scm.SCM.Tag"
 		]
     #{admin_users}.each { au -> user = BuildPermission.buildNewAccessList(au, adminPermissions)
       user.each { p, u -> auth_strategy.add(p, u) }

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -17,6 +17,15 @@
 # limitations under the License.
 #
 
+node.default['osl-jenkins']['restart_plugins'] = %w(
+  credentials:2.1.13
+  ssh-credentials:1.13
+  ssh-slaves:1.17
+  token-macro:2.1
+  durable-task:1.13
+  docker-plugin:0.16.2
+)
+
 node.default['osl-jenkins']['plugins'] = %w(
   docker-commons:1.6
   ssh-slaves:1.17
@@ -58,7 +67,6 @@ node.default['osl-jenkins']['plugins'] = %w(
   workflow-multibranch:2.14
   branch-api:2.0.8
   embeddable-build-status:1.9
-  token-macro:2.1
   workflow-step-api:2.9
   build-monitor-plugin:1.11+build.201701152243
   pipeline-multibranch-defaults:1.1
@@ -74,7 +82,6 @@ node.default['osl-jenkins']['plugins'] = %w(
   mailer:1.20
   pipeline-model-api:1.1.3
   pipeline-stage-step:2.2
-  durable-task:1.13
   scm-api:2.1.1
   cloud-stats:0.11
   plain-credentials:1.4
@@ -88,10 +95,6 @@ node.default['osl-jenkins']['plugins'] = %w(
 )
 
 include_recipe 'osl-jenkins::master'
-
-# Jenkins needs to be restarted before running the following script otherwise
-# the imports fail
-jenkins_command 'safe-restart'
 
 jenkins_script 'Add Docker Cloud' do
   command <<-EOH.gsub(/^ {4}/, '')

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -93,7 +93,6 @@ node.default['osl-jenkins']['plugins'] = %w(
   pipeline-input-step:2.8
   momentjs:1.1.1
   pipeline-build-step:2.5.1
-  yet-another-docker-plugin:0.1.0-rc37
   build-monitor-plugin:1.11+build.201701152243
   pipeline-multibranch-defaults:1.1
   pipeline-model-declarative-agent:1.1.1

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -70,18 +70,19 @@ node.default['osl-jenkins']['restart_plugins'] = %w(
   authentication-tokens:1.3
   embeddable-build-status:1.9
   matrix-auth:1.5
+  cloud-stats:0.11
+  config-file-provider:2.15.7
+  resource-disposer:0.6
+  openstack-cloud:2.22
 )
 
 node.default['osl-jenkins']['plugins'] = %w(
   docker-commons:1.6
-  resource-disposer:0.6
   pipeline-model-extensions:1.1.3
   emailext-template:1.0
   pipeline-stage-tags-metadata:1.1.3
   workflow-cps-global-lib:2.8
-  openstack-cloud:2.22
   bouncycastle-api:2.16.1
-  config-file-provider:2.15.7
   handlebars:1.1.1
   credentials-binding:1.11
   email-ext:2.57.2
@@ -101,7 +102,6 @@ node.default['osl-jenkins']['plugins'] = %w(
   workflow-basic-steps:2.4
   pipeline-model-api:1.1.3
   pipeline-stage-step:2.2
-  cloud-stats:0.11
   pipeline-graph-analysis:1.3
   workflow-aggregator:2.5
   job-restrictions:0.6
@@ -214,6 +214,25 @@ jenkins_script 'Add Docker Cloud' do
     }
   EOH
 end
+
+jenkins_script 'Add OpenStack cloud' do
+  command <<-EOH.gsub(/^ {4}/, '')
+    import jenkins.plugins.openstack.compute.*
+		import jenkins.model.*
+    import hudson.model.*;
+    
+    def instance = Jenkins.getInstance()
+      
+    JCloudsSlaveTemplate template = new JCloudsSlaveTemplate("template", "label", new SlaveOptions(
+          "img", "hw", "nw", "ud", 1, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", "cid", JCloudsCloud.SlaveType.JNLP, 4
+         ));
+    JCloudsCloud cloud = new JCloudsCloud("openstack", "identity", "credential", "endPointUrl", "zone", new SlaveOptions(
+             "IMG", "HW", "NW", "UD", 6, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", "CID", JCloudsCloud.SlaveType.SSH, 9
+             ), Arrays.asList(template));
+    instance.clouds.add(cloud);
+  EOH
+end
+
 
 jenkins_script 'Add GitHub OAuth config' do
   command <<-EOH.gsub(/^ {4}/, '')

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -43,55 +43,56 @@ node.default['osl-jenkins']['restart_plugins'] = %w(
   plain-credentials:1.4
   ace-editor:1.1
   jquery-detached:1.2.1
-  structs:1.6
+  structs:1.10
   display-url-api:2.0
   branch-api:2.0.8
   cloudbees-folder:6.0.3
-  scm-api:2.1.1
-  script-security:1.27
-  workflow-step-api:2.9
+  scm-api:2.2.0
+  script-security:1.31
+  workflow-step-api:2.12
   workflow-support:2.14
   workflow-scm-step:2.4
-  workflow-api:2.13
-  workflow-cps:2.30
+  workflow-api:2.20
+  workflow-cps:2.39
   workflow-job:2.10
   workflow-multibranch:2.14
   junit:1.20
   matrix-project:1.10
   mailer:1.20
-  git-client:2.4.5
-  git:3.3.0
+  jackson2-api:2.7.3
+  git-client:2.5.0
+  git:3.5.1
   git-server:1.7
-  github-api:1.85
+  github-api:1.86
   github:1.27.0
-  github-branch-source:2.0.5
+  github-branch-source:2.2.3
   github-oauth:0.27
   icon-shim:2.0.3
   authentication-tokens:1.3
   embeddable-build-status:1.9
   matrix-auth:1.5
   cloud-stats:0.11
-  config-file-provider:2.15.7
+  config-file-provider:2.16.2
   resource-disposer:0.6
   openstack-cloud:2.22
 )
 
 node.default['osl-jenkins']['plugins'] = %w(
-  docker-commons:1.6
+  docker-commons:1.8
   pipeline-model-extensions:1.1.3
   emailext-template:1.0
   pipeline-stage-tags-metadata:1.1.3
   workflow-cps-global-lib:2.8
   bouncycastle-api:2.16.1
   handlebars:1.1.1
-  credentials-binding:1.11
+  credentials-binding:1.13
   email-ext:2.57.2
   pipeline-milestone-step:1.3.1
   pipeline-rest-api:2.6
   docker-build-publish:1.3.2
-  pipeline-input-step:2.7
+  pipeline-input-step:2.8
   momentjs:1.1.1
-  pipeline-build-step:2.5
+  pipeline-build-step:2.5.1
   yet-another-docker-plugin:0.1.0-rc37
   build-monitor-plugin:1.11+build.201701152243
   pipeline-multibranch-defaults:1.1

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: osl-jenkins
 # Recipe:: powerci
 #
-# Copyright 2015, Oregon State University
+# Copyright 2017, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,22 @@
 # limitations under the License.
 #
 
+items = data_bag_item('osl_jenkins', 'powerci')
+admin_users = items['admin_users']
+normal_users = items['normal_users']
+client_id = items['client_id']
+client_secret = items['client_secret']
+
+ruby_block 'Set jenkins username/password if needed' do
+  block do
+    if ::File.exist?('/var/lib/jenkins/config.xml') &&
+       ::File.foreach('/var/lib/jenkins/config.xml').grep(/GithubSecurityRealm/).any?
+      node.run_state[:jenkins_username] = 'osuosl-manatee' # ~FC001
+      node.run_state[:jenkins_password] = items['cli_password'] # ~FC001
+    end
+  end
+end
+
 node.default['osl-jenkins']['restart_plugins'] = %w(
   credentials:2.1.13
   ssh-credentials:1.13
@@ -24,74 +40,73 @@ node.default['osl-jenkins']['restart_plugins'] = %w(
   token-macro:2.1
   durable-task:1.13
   docker-plugin:0.16.2
+  plain-credentials:1.4
+  ace-editor:1.1
+  jquery-detached:1.2.1
+  structs:1.6
+  display-url-api:2.0
+  branch-api:2.0.8
+  cloudbees-folder:6.0.3
+  scm-api:2.1.1
+  script-security:1.27
+  workflow-step-api:2.9
+  workflow-support:2.14
+  workflow-scm-step:2.4
+  workflow-api:2.13
+  workflow-cps:2.30
+  workflow-job:2.10
+  workflow-multibranch:2.14
+  junit:1.20
+  matrix-project:1.10
+  mailer:1.20
+  git-client:2.4.5
+  git:3.3.0
+  git-server:1.7
+  github-api:1.85
+  github:1.27.0
+  github-branch-source:2.0.5
+  github-oauth:0.27
+  icon-shim:2.0.3
+  matrix-auth:1.5
+  authentication-tokens:1.3
+
 )
 
 node.default['osl-jenkins']['plugins'] = %w(
   docker-commons:1.6
-  ssh-slaves:1.17
   resource-disposer:0.6
   pipeline-model-extensions:1.1.3
-  github:1.27.0
-  structs:1.6
   emailext-template:1.0
-  git:3.3.0
   pipeline-stage-tags-metadata:1.1.3
-  workflow-scm-step:2.4
-  github-api:1.85
   workflow-cps-global-lib:2.8
   openstack-cloud:2.22
-  cloudbees-folder:6.0.3
-  junit:1.20
   bouncycastle-api:2.16.1
-  display-url-api:2.0
-  matrix-project:1.10
   config-file-provider:2.15.7
   handlebars:1.1.1
   credentials-binding:1.11
-  workflow-cps:2.30
-  workflow-job:2.10
   email-ext:2.57.2
   pipeline-milestone-step:1.3.1
-  icon-shim:2.0.3
-  authentication-tokens:1.3
   pipeline-rest-api:2.6
   docker-build-publish:1.3.2
-  git-client:2.4.5
-  jquery-detached:1.2.1
   pipeline-input-step:2.7
   momentjs:1.1.1
-  workflow-support:2.14
   pipeline-build-step:2.5
   yet-another-docker-plugin:0.1.0-rc37
-  matrix-auth:1.5
-  workflow-multibranch:2.14
-  branch-api:2.0.8
   embeddable-build-status:1.9
-  workflow-step-api:2.9
   build-monitor-plugin:1.11+build.201701152243
   pipeline-multibranch-defaults:1.1
   pipeline-model-declarative-agent:1.1.1
-  ace-editor:1.1
   docker-workflow:1.10
   workflow-durable-task-step:2.11
-  workflow-api:2.13
-  github-branch-source:2.0.5
-  docker-plugin:0.16.2
   pipeline-model-definition:1.1.3
   workflow-basic-steps:2.4
-  mailer:1.20
   pipeline-model-api:1.1.3
   pipeline-stage-step:2.2
-  scm-api:2.1.1
   cloud-stats:0.11
-  plain-credentials:1.4
-  github-oauth:0.27
   pipeline-graph-analysis:1.3
-  script-security:1.27
   workflow-aggregator:2.5
   job-restrictions:0.6
   pipeline-stage-view:2.6
-  git-server:1.7
 )
 
 include_recipe 'osl-jenkins::master'
@@ -199,4 +214,121 @@ jenkins_script 'Add Docker Cloud' do
       println "--> no 'docker-plugin' plugin installed"
     }
   EOH
+end
+
+jenkins_script 'Add GitHub OAuth config' do
+  command <<-EOH.gsub(/^ {4}/, '')
+		import hudson.security.*
+		import jenkins.model.*
+		import org.jenkinsci.plugins.GithubAuthorizationStrategy
+		import hudson.security.AuthorizationStrategy
+		import hudson.security.SecurityRealm
+		import org.jenkinsci.plugins.GithubSecurityRealm
+		import hudson.security.ProjectMatrixAuthorizationStrategy
+		import hudson.security.csrf.DefaultCrumbIssuer
+
+		Jenkins.instance.crumbIssuer = new DefaultCrumbIssuer(true)
+
+		// Authentication
+		String githubWebUri = 'https://github.com'
+		String githubApiUri = 'https://api.github.com'
+		String clientID = '#{client_id}'
+		String clientSecret = '#{client_secret}'
+		String oauthScopes = 'read:org'
+		SecurityRealm github_realm = new GithubSecurityRealm(githubWebUri, githubApiUri, clientID, clientSecret, oauthScopes)
+		//check for equality, no need to modify the runtime if no settings changed
+		if(!github_realm.equals(Jenkins.instance.getSecurityRealm())) {
+				Jenkins.instance.setSecurityRealm(github_realm)
+				Jenkins.instance.save()
+		}
+
+		// Authorization
+		class BuildPermission {
+			static buildNewAccessList(userOrGroup, permissions) {
+				def newPermissionsMap = [:]
+				permissions.each {
+					newPermissionsMap.put(Permission.fromId(it), userOrGroup)
+				}
+				return newPermissionsMap
+			}
+		}
+
+		auth_strategy = new hudson.security.ProjectMatrixAuthorizationStrategy()
+
+		authenticatedPermissions = [ "hudson.model.Hudson.Read" ]
+		authenticated = BuildPermission.buildNewAccessList("authenticated", authenticatedPermissions)
+		authenticated.each { p, u -> auth_strategy.add(p, u) }
+
+    anonPermissions = [ "hudson.model.Hudson.Read" ]
+		anon = BuildPermission.buildNewAccessList("anonymous", anonPermissions)
+		anon.each { p, u -> auth_strategy.add(p, u) }
+
+
+		adminPermissions = [
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Create",
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Delete",
+      "com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains",
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Update",
+      "com.cloudbees.plugins.credentials.CredentialsProvider.View",
+      "hudson.model.Computer.Build",
+      "hudson.model.Computer.Configure",
+      "hudson.model.Computer.Connect",
+      "hudson.model.Computer.Create",
+      "hudson.model.Computer.Delete",
+      "hudson.model.Computer.Disconnect",
+      "hudson.model.Hudson.Administer",
+      "hudson.model.Hudson.Read",
+      "hudson.model.Item.Build",
+      "hudson.model.Item.Cancel",
+      "hudson.model.Item.Configure",
+      "hudson.model.Item.Create",
+      "hudson.model.Item.Delete",
+      "hudson.model.Item.Discover",
+      "hudson.model.Item.Read",
+      "hudson.model.Item.ViewStatus",
+      "hudson.model.Item.Workspace",
+      "hudson.model.Run.Delete",
+      "hudson.model.Run.Update",
+      "hudson.model.View.Configure",
+      "hudson.model.View.Create",
+      "hudson.model.View.Delete",
+      "hudson.model.View.Read"
+		]
+    #{admin_users}.each { au -> user = BuildPermission.buildNewAccessList(au, adminPermissions)
+      user.each { p, u -> auth_strategy.add(p, u) }
+    }
+
+		userPermissions = [
+			"hudson.model.Item.Build",
+			"hudson.model.Item.Cancel",
+			"hudson.model.Item.Configure",
+			"hudson.model.Item.Create",
+			"hudson.model.Item.Delete",
+			"hudson.model.Item.Discover",
+			"hudson.model.Item.Read",
+			"hudson.model.Item.ViewStatus",
+			"hudson.model.Item.Workspace"
+		]
+    #{normal_users}.each { nu -> user = BuildPermission.buildNewAccessList(nu, userPermissions)
+      user.each { p, u -> auth_strategy.add(p, u) }
+    }
+
+
+		//check for equality, no need to modify the runtime if no settings changed
+		if(!auth_strategy.equals(Jenkins.instance.getAuthorizationStrategy())) {
+				Jenkins.instance.setAuthorizationStrategy(auth_strategy)
+				Jenkins.instance.save()
+		}
+
+	EOH
+end
+
+ruby_block 'Set jenkins username/password if needed' do
+  block do
+    if ::File.exist?('/var/lib/jenkins/config.xml') &&
+       ::File.foreach('/var/lib/jenkins/config.xml').grep(/GithubSecurityRealm/).any?
+      node.run_state[:jenkins_username] = 'osuosl-manatee' # ~FC001
+      node.run_state[:jenkins_password] = items['cli_password'] # ~FC001
+    end
+  end
 end

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -45,14 +45,14 @@ node.default['osl-jenkins']['restart_plugins'] = %w(
   jquery-detached:1.2.1
   structs:1.10
   display-url-api:2.0
-  branch-api:2.0.8
   cloudbees-folder:6.0.3
   scm-api:2.2.0
+  branch-api:2.0.8
   script-security:1.31
   workflow-step-api:2.12
-  workflow-support:2.14
   workflow-scm-step:2.4
   workflow-api:2.20
+  workflow-support:2.14
   workflow-cps:2.39
   workflow-job:2.10
   workflow-multibranch:2.14

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -215,24 +215,66 @@ jenkins_script 'Add Docker Cloud' do
   EOH
 end
 
-jenkins_script 'Add OpenStack cloud' do
+jenkins_script 'Add OpenStack Cloud' do
   command <<-EOH.gsub(/^ {4}/, '')
     import jenkins.plugins.openstack.compute.*
 		import jenkins.model.*
     import hudson.model.*;
-    
+
     def instance = Jenkins.getInstance()
-      
-    JCloudsSlaveTemplate template = new JCloudsSlaveTemplate("template", "label", new SlaveOptions(
-          "img", "hw", "nw", "ud", 1, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", "cid", JCloudsCloud.SlaveType.JNLP, 4
-         ));
-    JCloudsCloud cloud = new JCloudsCloud("openstack", "identity", "credential", "endPointUrl", "zone", new SlaveOptions(
-             "IMG", "HW", "NW", "UD", 6, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", "CID", JCloudsCloud.SlaveType.SSH, 9
-             ), Arrays.asList(template));
+
+    JCloudsSlaveTemplate template = new JCloudsSlaveTemplate(
+      "template",
+      "label",
+      new SlaveOptions(
+          "img",
+          "hw",
+          "nw",
+          "ud",
+          1,
+          "public",
+          "sg",
+          "az",
+          2,
+          "kp",
+          3,
+          "jvmo",
+          "fsRoot",
+          "cid",
+          JCloudsCloud.SlaveType.JNLP,
+          4
+      )
+    );
+    JCloudsCloud cloud = new JCloudsCloud(
+      "osl-openstack", // name for the openstack cloud
+      "identity", // format: TENANT_NAME:USER_NAME
+      "credential", //password for the username
+      "endPointUrl", //OpenStack Auth URL
+      "zone",
+      new SlaveOptions(
+             "IMG", //Image
+             "HW",
+             "NW",
+             "UD",
+             6,
+             null,
+             "SG",
+             "AZ",
+             7,
+             "KP",
+             8,
+             "JVMO",
+             "FSrOOT",
+             "CID",
+             JCloudsCloud.SlaveType.SSH,
+             9
+      ),
+      Arrays.asList(template)
+    );
+
     instance.clouds.add(cloud);
   EOH
 end
-
 
 jenkins_script 'Add GitHub OAuth config' do
   command <<-EOH.gsub(/^ {4}/, '')

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -7,6 +7,15 @@ describe 'osl-jenkins::powerci' do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
       include_context 'common_stubs'
+      before do
+        stub_data_bag_item('osl_jenkins', 'powerci').and_return(
+          admin_users: ['testadmin'],
+          normal_users: ['testuser'],
+          client_id: '123456789',
+          client_secret: '0987654321',
+          cli_password: 'abcdefghi'
+        )
+      end
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
@@ -43,6 +52,12 @@ describe 'osl-jenkins::powerci' do
       end
       it do
         expect(chef_run).to execute_jenkins_script('Add Docker Cloud')
+      end
+      it do
+        expect(chef_run).to execute_jenkins_script('Add GitHub OAuth config')
+      end
+      it do
+        expect(chef_run).to run_ruby_block('Set jenkins username/password if needed')
       end
     end
   end

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -41,6 +41,9 @@ describe 'osl-jenkins::powerci' do
           expect(chef_run.jenkins_plugin(plugin)).to notify('jenkins_command[safe-restart]')
         end
       end
+      it do
+        expect(chef_run).to execute_jenkins_script('Add Docker Cloud')
+      end
     end
   end
 end

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -57,6 +57,9 @@ describe 'osl-jenkins::powerci' do
         expect(chef_run).to execute_jenkins_script('Add GitHub OAuth config')
       end
       it do
+        expect(chef_run).to execute_jenkins_script('Add OpenStack Cloud')
+      end
+      it do
         expect(chef_run).to run_ruby_block('Set jenkins username/password if needed')
       end
     end

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -22,22 +22,21 @@ describe 'osl-jenkins::powerci' do
       %w(
         build-monitor-plugin:1.11+build.201701152243
         cloud-stats:0.11
-        config-file-provider:2.15.7
-        docker-commons:1.6
+        config-file-provider:2.16.2
+        docker-commons:1.8
         docker-plugin:0.16.2
         docker-build-publish:1.3.2
         email-ext:2.57.2
         emailext-template:1.0
         embeddable-build-status:1.9
-        git-client:2.4.5
-        github-api:1.85
+        git-client:2.5.0
+        github-api:1.86
         github-oauth:0.27
         job-restrictions:0.6
         matrix-project:1.10
         openstack-cloud:2.22
         pipeline-multibranch-defaults:1.1
         resource-disposer:0.6
-        yet-another-docker-plugin:0.1.0-rc37
       ).each do |plugins_version|
         plugin, version = plugins_version.split(':')
         it do

--- a/test/integration/data_bags/osl_jenkins/powerci.json
+++ b/test/integration/data_bags/osl_jenkins/powerci.json
@@ -1,0 +1,38 @@
+{
+  "id": "powerci",
+  "admin_users": {
+    "encrypted_data": "lo2gkjsekYdF1G84KP7/nWj502HLTmzIEx1Eh79AZi0vqAe9KNjCazvx8/Nb\nViAGy9QOSKFs7TTq+hWtZ3Uogwtjjx0AMdZcz6Z08rCqhOw=\n",
+    "hmac": "HUuHa5LQQsSZt0NoqawFcyb1m0/aowIqN4yZErRjx4I=\n",
+    "iv": "LI0BevBadi2hdA3mBH9ohQ==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "normal_users": {
+    "encrypted_data": "qiH13YG7wsUym4NV3LhkgMvTjXCF/HSV5ZC0ao5wdu+tKd8VWaYq+5ZizQ37\nprWh\n",
+    "hmac": "eKsROt5132DRNUNOkqP2jxQT4cQ0iQXa245386sUM54=\n",
+    "iv": "5tUAviu5I97HzSvfNQP0yQ==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "client_id": {
+    "encrypted_data": "ZH1ImJ4Lg2l6ZWhI4SnH3XJXXxdce77d5IB4qMHcImGi6NxFgAiEfD8Zxdl6\nKC70\n",
+    "hmac": "/8C169cx0Ukdkxoy4Rzu9uB33j2nxSpWtFDypWb7ZZc=\n",
+    "iv": "nDMgCSrzIfIZ0x7siaR5qA==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "client_secret": {
+    "encrypted_data": "IIsr2Aca7TrPVR9sXMgZ2BVyAwEFoadq8frX/hD2a7Gq6u1jsxf7t61m3cLM\nirV/7RzpFllQgg67SmQhu/lbSQ==\n",
+    "hmac": "z6q8ytFM9S/1QLESmGpRS3z62pj8g0N0kQ/XNfH3hfQ=\n",
+    "iv": "+OBxfVZZWt0EbnHVqB8VFg==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "cli_password": {
+    "encrypted_data": "FjeWXD83C48Q5MG8fWWC6NDMj7Aada1fziBmO64SGp6DA9TR/KQErsCoMQjG\nupwSbhvtoUIms8PlUBQo6a2Ofg==\n",
+    "hmac": "jPFWMolOsyZBp9UzLFhe3gMnr4s+d/8za7RKN9Gl23c=\n",
+    "iv": "pn8b8ZcqyWF+MXqOYLcE/g==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  }
+}

--- a/test/integration/data_bags/osl_jenkins/powerci.json
+++ b/test/integration/data_bags/osl_jenkins/powerci.json
@@ -1,37 +1,37 @@
 {
   "id": "powerci",
   "admin_users": {
-    "encrypted_data": "lo2gkjsekYdF1G84KP7/nWj502HLTmzIEx1Eh79AZi0vqAe9KNjCazvx8/Nb\nViAGy9QOSKFs7TTq+hWtZ3Uogwtjjx0AMdZcz6Z08rCqhOw=\n",
-    "hmac": "HUuHa5LQQsSZt0NoqawFcyb1m0/aowIqN4yZErRjx4I=\n",
-    "iv": "LI0BevBadi2hdA3mBH9ohQ==\n",
+    "encrypted_data": "kTKFPgtVUnFZLY2TjMq5befkKHdq3tG1hXaYyZPOoUmePNwPL9/k0JERG4Vm\nDTSeXh1Ml+HmkfGuJPpq7MN3jS6tyzOZSeIyfUD/RfpqrFg=\n",
+    "hmac": "nzzosaMilWUIRe1lxmwHSs16Lqv20UUxHNaeQuNI9Ko=\n",
+    "iv": "lOzoIo1pKfDJkP/RruJl3g==\n",
     "version": 2,
     "cipher": "aes-256-cbc"
   },
   "normal_users": {
-    "encrypted_data": "qiH13YG7wsUym4NV3LhkgMvTjXCF/HSV5ZC0ao5wdu+tKd8VWaYq+5ZizQ37\nprWh\n",
-    "hmac": "eKsROt5132DRNUNOkqP2jxQT4cQ0iQXa245386sUM54=\n",
-    "iv": "5tUAviu5I97HzSvfNQP0yQ==\n",
+    "encrypted_data": "Pg/2XzTVc2DA+UIT727iH+6/lVa+xGcJ2SEdG8GbEizxFyxZJbn7a5tmzs48\ndzEH\n",
+    "hmac": "fTDIIjBBmeZ1LKjAH1iTmT0HNAwOkxmZAIPDNy9il/E=\n",
+    "iv": "rpPggP9NDPauYEsQFvLfqQ==\n",
     "version": 2,
     "cipher": "aes-256-cbc"
   },
   "client_id": {
-    "encrypted_data": "ZH1ImJ4Lg2l6ZWhI4SnH3XJXXxdce77d5IB4qMHcImGi6NxFgAiEfD8Zxdl6\nKC70\n",
-    "hmac": "/8C169cx0Ukdkxoy4Rzu9uB33j2nxSpWtFDypWb7ZZc=\n",
-    "iv": "nDMgCSrzIfIZ0x7siaR5qA==\n",
+    "encrypted_data": "Psdv18S5ohlqkXiUfSVVcQuzLygpgTD43ZMRxYetzmSrf7u850CTOJp44nAB\n8jvg\n",
+    "hmac": "eIs0KIywZqy8ruZLwukkTE75qLirwjEuslkUnymoPPs=\n",
+    "iv": "eT9bLTI1J4PUP78oMc9O7Q==\n",
     "version": 2,
     "cipher": "aes-256-cbc"
   },
   "client_secret": {
-    "encrypted_data": "IIsr2Aca7TrPVR9sXMgZ2BVyAwEFoadq8frX/hD2a7Gq6u1jsxf7t61m3cLM\nirV/7RzpFllQgg67SmQhu/lbSQ==\n",
-    "hmac": "z6q8ytFM9S/1QLESmGpRS3z62pj8g0N0kQ/XNfH3hfQ=\n",
-    "iv": "+OBxfVZZWt0EbnHVqB8VFg==\n",
+    "encrypted_data": "O4pZOh6L7t6BTYGypkzXxHSfeLxp9M3dKF0rK5uxIugU2CIo9lMY3owgubws\n4kE0C9NBq/jXX/aywsX6Z8bX2w==\n",
+    "hmac": "YklHIGJ3jyaQbsMGlyTBCa7EGoygyDRjYzsVox/bQOE=\n",
+    "iv": "/PtNEL72DAZroPRdO0Y/9Q==\n",
     "version": 2,
     "cipher": "aes-256-cbc"
   },
   "cli_password": {
-    "encrypted_data": "FjeWXD83C48Q5MG8fWWC6NDMj7Aada1fziBmO64SGp6DA9TR/KQErsCoMQjG\nupwSbhvtoUIms8PlUBQo6a2Ofg==\n",
-    "hmac": "jPFWMolOsyZBp9UzLFhe3gMnr4s+d/8za7RKN9Gl23c=\n",
-    "iv": "pn8b8ZcqyWF+MXqOYLcE/g==\n",
+    "encrypted_data": "qG6Y4qa5MTF/InNP0TzyqHPg7gsjvwD696vfb4WFfJ8pTRVFid86Sw6Qq7nL\ndNixkBO+PYhRjV1g00ZL86qD2g==\n",
+    "hmac": "rJZqcbuPgtrMcUAL4RuYQGHszNIiNj60TIdSAytXOYI=\n",
+    "iv": "MYAeF290yzE/M6pmdDf7eQ==\n",
     "version": 2,
     "cipher": "aes-256-cbc"
   }

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -12,17 +12,17 @@ end
 
 describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localhost:8080/ list-plugins') do
   %w(
-    docker-commons:1.6
+    docker-commons:1.8
     ssh-slaves:1.17
     resource-disposer:0.6
     pipeline-model-extensions:1.1.3
     github:1.27.0
-    structs:1.6
+    structs:1.10
     emailext-template:1.0
-    git:3.3.0
+    git:3.5.1
     pipeline-stage-tags-metadata:1.1.3
     workflow-scm-step:2.4
-    github-api:1.85
+    github-api:1.86
     workflow-cps-global-lib:2.8
     openstack-cloud:2.22
     cloudbees-folder:6.0.3
@@ -30,10 +30,10 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     bouncycastle-api:2.16.1
     display-url-api:2.0
     matrix-project:1.10
-    config-file-provider:2.15.7
+    config-file-provider:2.16.2
     handlebars:1.1.1
-    credentials-binding:1.11
-    workflow-cps:2.30
+    credentials-binding:1.13
+    workflow-cps:2.39
     workflow-job:2.10
     email-ext:2.57.2
     pipeline-milestone-step:1.3.1
@@ -41,28 +41,27 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     authentication-tokens:1.3
     pipeline-rest-api:2.6
     docker-build-publish:1.3.2
-    git-client:2.4.5
+    git-client:2.5.0
     jquery-detached:1.2.1
-    pipeline-input-step:2.7
+    pipeline-input-step:2.8
     momentjs:1.1.1
     ssh-credentials:1.13
     workflow-support:2.14
-    yet-another-docker-plugin:0.1.0-rc37
-    pipeline-build-step:2.5
+    pipeline-build-step:2.5.1
     matrix-auth:1.5
     workflow-multibranch:2.14
     branch-api:2.0.8
     embeddable-build-status:1.9
     token-macro:2.1
-    workflow-step-api:2.9
+    workflow-step-api:2.12
     build-monitor-plugin:1.11\+build.201701152243
     pipeline-multibranch-defaults:1.1
     pipeline-model-declarative-agent:1.1.1
     ace-editor:1.1
     docker-workflow:1.10
     workflow-durable-task-step:2.11
-    workflow-api:2.13
-    github-branch-source:2.0.5
+    workflow-api:2.20
+    github-branch-source:2.2.3
     docker-plugin:0.16.2
     pipeline-model-definition:1.1.3
     workflow-basic-steps:2.4
@@ -71,16 +70,17 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     pipeline-model-api:1.1.3
     pipeline-stage-step:2.2
     durable-task:1.13
-    scm-api:2.1.1
+    scm-api:2.2.0
     cloud-stats:0.11
     plain-credentials:1.4
     github-oauth:0.27
     pipeline-graph-analysis:1.3
-    script-security:1.27
+    script-security:1.31
     workflow-aggregator:2.5
     job-restrictions:0.6
     pipeline-stage-view:2.6
     git-server:1.7
+    jackson2-api:2.7.3
   ).each do |plugins_version|
     plugin, version = plugins_version.split(':')
     its(:stdout) { should match(/^#{plugin}.*#{version}[\s\(]?/) }


### PR DESCRIPTION
This adds a jenkins_script that configures a docker cloud. It also avoids the problem of creating duplicate entries when run multiple time which was a problem I had with the original Ansible setup. 

This Works:tm: but I wasn't sure if we wanted to pull out specific settings and make them attributes, or go about this some other way. Not sure if this something that we want to be able to reuse and should be put in another recipe and then just set the attributes in the powerci recipe.

Thoughts?