### PR TITLE
don't close prs even if they break

### DIFF
--- a/templates/default/site_pr_builder_config.xml.erb
+++ b/templates/default/site_pr_builder_config.xml.erb
@@ -51,7 +51,7 @@
       <useGitHubHooks>true</useGitHubHooks>
       <permitAll>true</permitAll>
       <whitelist></whitelist>
-      <autoCloseFailedPullRequests>true</autoCloseFailedPullRequests>
+      <autoCloseFailedPullRequests>false</autoCloseFailedPullRequests>
       <displayBuildErrorsOnDownstreamBuilds>true</displayBuildErrorsOnDownstreamBuilds>
       <whiteListTargetBranches>
         <org.jenkinsci.plugins.ghprb.GhprbBranch>


### PR DESCRIPTION
Turns out the pr builder job has an advanced option to delete failed PRs, defaulting to 'true' this should prevent the builder jobs from closing prs.