### PR TITLE
setup keys to use with openstack taster

### DIFF
--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -34,6 +34,27 @@ cookbook_file '/home/alfred/.gitconfig' do
   group 'alfred'
 end
 
+# put the key associated with the openstack_taster's users on various clusters
+# so that it can access the instances once created
+node.override['osl-jenkins']['secrets_databag'] = 'osl_jenkins'
+node.override['osl-jenkins']['secrets_item'] = 'jenkins1'
+
+openstack_access_keys = credential_secrets['jenkins']['packer_pipeline']
+
+file '/home/alfred/.ssh/bento_alfred_id' do
+  content openstack_access_keys['private_key']
+  owner 'alfred'
+  group 'alfred'
+  mode 0600
+end
+
+file '/home/alfred/.ssh/bento_alfred_id.pub' do
+  content openstack_access_keys['public_key']
+  owner 'alfred'
+  group 'alfred'
+  mode 0600
+end
+
 # put the credentials for accessing openstack in alfred's home dir from the
 # encrypted databag
 node.override['osl-jenkins']['secrets_databag'] = 'osl_jenkins'
@@ -62,28 +83,6 @@ if node['kernel']['machine'] == 'ppc64le'
   end
 else
   include_recipe 'sbp_packer::default'
-end
-
-# put the key associated with the openstack_taster's users on various clusters
-# so that it can access the instances once created
-node.override['osl-jenkins']['secrets_databag'] = 'osl_jenkins'
-node.override['osl-jenkins']['secrets_item'] = 'jenkins1'
-
-secrets = credential_secrets
-openstack_access_keys = secrets['jenkins']['packer_pipeline']
-
-file '/home/alfred/.ssh/bento_alfred_id' do
-  content openstack_access_keys['private_key']
-  owner 'alfred'
-  group 'alfred'
-  mode 0600
-end
-
-file '/home/alfred/.ssh/bento_alfred_id.pub' do
-  content openstack_access_keys['public_key']
-  owner 'alfred'
-  group 'alfred'
-  mode 0600
 end
 
 # install dependencies for gem dependencies

--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -41,15 +41,19 @@ node.override['osl-jenkins']['secrets_item'] = 'jenkins1'
 
 openstack_access_keys = credential_secrets['jenkins']['packer_pipeline']
 
-file '/home/alfred/.ssh/packer_alfred_id' do
-  content openstack_access_keys['private_key']
+# this is the key that's put on the instances created by openstack_taster
+# it has been manually put in all OpenStack Taster account on our clusters.
+file '/home/alfred/.ssh/packer_alfred_id.pub' do
+  content openstack_access_keys['public_key']
   owner 'alfred'
   group 'alfred'
   mode 0600
 end
 
-file '/home/alfred/.ssh/packer_alfred_id.pub' do
-  content openstack_access_keys['public_key']
+# this is the private key part of the above keypair to actually ssh into
+# those instances and run our suites
+file '/home/alfred/.ssh/packer_alfred_id' do
+  content openstack_access_keys['private_key']
   owner 'alfred'
   group 'alfred'
   mode 0600

--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -41,14 +41,14 @@ node.override['osl-jenkins']['secrets_item'] = 'jenkins1'
 
 openstack_access_keys = credential_secrets['jenkins']['packer_pipeline']
 
-file '/home/alfred/.ssh/bento_alfred_id' do
+file '/home/alfred/.ssh/packer_alfred_id' do
   content openstack_access_keys['private_key']
   owner 'alfred'
   group 'alfred'
   mode 0600
 end
 
-file '/home/alfred/.ssh/bento_alfred_id.pub' do
+file '/home/alfred/.ssh/packer_alfred_id.pub' do
   content openstack_access_keys['public_key']
   owner 'alfred'
   group 'alfred'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,10 +50,18 @@ shared_context 'data_bag_stubs' do
       .and_return(
         id: 'packer_pipeline_creds'
       )
-      .and_raise(Net::HTTPServerException.new(
-                   'osl_jenkins databag not found',
-                   Net::HTTPResponse.new('1.1', '404', '')
-      ))
+
+    allow(Chef::EncryptedDataBagItem).to receive(:load)
+      .with('osl_jenkins', 'jenkins1')
+      .and_return(
+        id: 'jenkins1',
+        'jenkins' => {
+          'packer_pipeline' => {
+            'public_key' => 'public key for openstack_taster goes here',
+            'private_key' => 'private key for openstack_taster goes here'
+          }
+        }
+      )
   end
 end
 shared_context 'cookbook_uploader' do

--- a/spec/unit/recipes/packer_pipeline_node.rb
+++ b/spec/unit/recipes/packer_pipeline_node.rb
@@ -41,7 +41,7 @@ describe 'osl-jenkins::packer_pipeline_node' do
       end
 
       it do
-        expect(chef_run).to create_file('/home/alfred/.ssh/bento_alfred_id').with(
+        expect(chef_run).to create_file('/home/alfred/.ssh/packer_alfred_id').with(
           user: 'alfred',
           group: 'alfred',
           mode: 0600,
@@ -50,7 +50,7 @@ describe 'osl-jenkins::packer_pipeline_node' do
       end
 
       it do
-        expect(chef_run).to create_file('/home/alfred/.ssh/bento_alfred_id.pub').with(
+        expect(chef_run).to create_file('/home/alfred/.ssh/packer_alfred_id.pub').with(
           user: 'alfred',
           group: 'alfred',
           mode: 0600,

--- a/spec/unit/recipes/packer_pipeline_node.rb
+++ b/spec/unit/recipes/packer_pipeline_node.rb
@@ -46,7 +46,7 @@ describe 'osl-jenkins::packer_pipeline_node' do
           group: 'alfred',
           mode: 0600,
           content: 'private key for openstack_taster goes here'
-          )
+        )
       end
 
       it do
@@ -55,7 +55,7 @@ describe 'osl-jenkins::packer_pipeline_node' do
           group: 'alfred',
           mode: 0600,
           content: 'public key for openstack_taster goes here'
-          )
+        )
       end
 
       it do

--- a/spec/unit/recipes/packer_pipeline_node.rb
+++ b/spec/unit/recipes/packer_pipeline_node.rb
@@ -41,6 +41,24 @@ describe 'osl-jenkins::packer_pipeline_node' do
       end
 
       it do
+        expect(chef_run).to create_file('/home/alfred/.ssh/bento_alfred_id').with(
+          user: 'alfred',
+          group: 'alfred',
+          mode: 0600,
+          content: 'private key for openstack_taster goes here'
+          )
+      end
+
+      it do
+        expect(chef_run).to create_file('/home/alfred/.ssh/bento_alfred_id.pub').with(
+          user: 'alfred',
+          group: 'alfred',
+          mode: 0600,
+          content: 'public key for openstack_taster goes here'
+          )
+      end
+
+      it do
         expect(chef_run).to create_directory('/home/alfred/workspace').with(
           user: 'alfred',
           group: 'alfred'

--- a/test/integration/data_bags/osl_jenkins/jenkins1.json
+++ b/test/integration/data_bags/osl_jenkins/jenkins1.json
@@ -1,0 +1,10 @@
+{
+  "id": "jenkins1",
+  "jenkins": {
+    "encrypted_data": "s3IQB23y+WhbrfcFlIB3oOwR2FtQu9TUDcvcJ6hYOR/98CQXBVSpi/EnjQXt\nbymlVAvyXAFrIY+bqCSZ5Mvvmlr+pj2JVV7REJ7QV3+VXnuviFgyh4DY8Akp\nH2/N2ZSs3XYps4bHLzYde+Dz39zKnMN4UsTLNssJJBVjpqclwjtjfZBv0PAk\nWF8I2x20FsWJ99ltSTGZggHfwwVV/HAtUkI2+YfYy9fHAKV3sC/IWrg=\n",
+    "hmac": "jvYz+DZi8vAAAdctdZ1QVH12h7d5gdRcr+LPkcO+reo=\n",
+    "iv": "qof3agHjGsELXs1kROQuXQ==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  }
+}

--- a/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
+++ b/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
@@ -5,10 +5,9 @@ describe file('/home/alfred/.gitconfig') do
   it { should exist }
   it { should be_a_file }
   it do
-    should contain(
-      'pr  = "!f() { git fetch -fu ${2:-$(git remote |grep ^upstream || echo origin)} \
-      refs/pull/$1/head:pr/$1 && git checkout pr/$1; }; f"'
-    ).after(/[alias]/)
+    should contain(%r{pr  = "!f() { git fetch -fu ${2:-$(git remote |
+  grep ^upstream || echo origin)} refs/pull/$1/head:pr/$1
+  && git checkout pr/$1; }; f}x).after(/[alias]/)
   end
 end
 

--- a/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
+++ b/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
@@ -24,10 +24,30 @@ describe file('/usr/local/bin/packer') do
   it { should be_executable }
 end
 
+describe file('/home/alfred/.ssh/bento_alfred_id') do
+  it { should be_a_file }
+  it { should be_owned_by 'alfred' }
+  it { should be_grouped_into 'alfred' }
+  it { should be_mode 600 }
+end
+
+describe file('/home/alfred/.ssh/bento_alfred_id.pub') do
+  it { should be_a_file }
+  it { should be_owned_by 'alfred' }
+  it { should be_grouped_into 'alfred' }
+  it { should be_mode 600 }
+end
+
 describe file('/home/alfred/openstack_credentials.json') do
   it { should be_a_file }
   it { should be_owned_by 'alfred' }
   it { should be_grouped_into 'alfred' }
+  it { should be_mode 600 }
+end
+
+describe file('/home/alfred/openstack_credentials.json') do
+  it { should be_a_file }
+  it { should be_owned_by 'alfred' }
   it { should be_grouped_into 'alfred' }
   it { should be_mode 600 }
 end

--- a/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
+++ b/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
@@ -24,14 +24,14 @@ describe file('/usr/local/bin/packer') do
   it { should be_executable }
 end
 
-describe file('/home/alfred/.ssh/bento_alfred_id') do
+describe file('/home/alfred/.ssh/packer_alfred_id') do
   it { should be_a_file }
   it { should be_owned_by 'alfred' }
   it { should be_grouped_into 'alfred' }
   it { should be_mode 600 }
 end
 
-describe file('/home/alfred/.ssh/bento_alfred_id.pub') do
+describe file('/home/alfred/.ssh/packer_alfred_id.pub') do
   it { should be_a_file }
   it { should be_owned_by 'alfred' }
   it { should be_grouped_into 'alfred' }


### PR DESCRIPTION
openstack_taster requires the private key, whose public key part is put on the openstack clusters, to be accessible locally so as to be able to SSH into the instances.

@DesertBeagle had put the key in data bags long back, but I hadn't made them available on the nodes.
This should take care of that.