### PR TITLE
install openstack_taster as a chef_gem explicitly

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -301,3 +301,13 @@ suites:
       - recipe[osl-jenkins::packer_pipeline_node]
     excludes:
       - centos-6.9
+    attributes:
+      osl-jenkins:
+        credentials:
+          jenkins:
+            packer_pipeline:
+              user: <%= ENV['JENKINS_USER'] %>
+              api_token: <%= ENV['JENKINS_PASS'] %>
+              trigger_token: <%= ENV['TRIGGER_TOKEN'] %>
+              public_key: 'ssh-rsa THIS_IS_A_PUBLIC_KEY'
+              private_key: '-----BEGIN RSA PRIVATE KEY-----END RSA PRIVATE KEY-----'

--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -89,11 +89,12 @@ else
   include_recipe 'sbp_packer::default'
 end
 
-# install dependencies for gem dependencies
+# install dependencies for gem dependencies at compile time so that chef_gem can use them
+node.override['build-essential']['compile_time'] = true
 include_recipe 'build-essential::default'
 
 # install openstack_taster
-gem_package 'openstack_taster' do
+chef_gem 'openstack_taster' do
   version node['osl-jenkins']['packer_pipeline']['openstack_taster_version']
   options '--no-user-install'
   clear_sources true

--- a/spec/unit/recipes/packer_pipeline_node.rb
+++ b/spec/unit/recipes/packer_pipeline_node.rb
@@ -81,7 +81,7 @@ describe 'osl-jenkins::packer_pipeline_node' do
       end
 
       it do
-        expect(chef_run).to install_gem_package('openstack_taster').with(
+        expect(chef_run).to install_chef_gem('openstack_taster').with(
           options: '--no-user-install'
         )
       end


### PR DESCRIPTION
This would also require installing the dependencies at compile_time
since chef installs chef_gem at compile time too.

It seems until now Chef was simply falling back to installing openstack_taster
by default as a chef_gem when a system ruby was not available.
This didn't hit our radar until we saw a machine which had both rubies.