### PR TITLE
Update to Jenkins 2.60.2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -20,6 +20,7 @@ depends          'poise-python'
 depends          'git'
 depends          'sudo'
 depends          'sbp_packer', '= 1.4.7'
+depends          'yum-plugin-versionlock'
 
 supports         'centos', '~> 6.0'
 supports         'centos', '~> 7.0'

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -20,7 +20,7 @@
 # Don't automatically update jenkins
 node.override['yum-cron']['yum_parameter'] = '-x jenkins'
 
-node.default['jenkins']['master']['version'] = '2.46.3-1.1'
+node.default['jenkins']['master']['version'] = '2.60.2-1.1'
 node.default['jenkins']['master']['listen_address'] = '127.0.0.1'
 
 node.default['java']['jdk_version'] = '8'

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -39,6 +39,14 @@ node.default['certificate'] = [{
   }
 }]
 
+include_recipe 'yum-plugin-versionlock'
+
+yum_version_lock 'jenkins' do
+  version_split = node['jenkins']['master']['version'].split('-')
+  version version_split[0]
+  release version_split[1]
+end
+
 include_recipe 'java'
 include_recipe 'jenkins::master'
 include_recipe 'certificate::manage_by_attributes'

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -11,6 +11,13 @@ describe 'osl-jenkins::master' do
         expect { chef_run }.to_not raise_error
       end
       it do
+        expect(chef_run).to add_yum_version_lock('jenkins')
+          .with(
+            version: '2.46.3',
+            release: '1.1'
+          )
+      end
+      it do
         expect(chef_run).to install_package('jenkins').with(version: '2.46.3-1.1')
       end
       case p

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -13,12 +13,12 @@ describe 'osl-jenkins::master' do
       it do
         expect(chef_run).to add_yum_version_lock('jenkins')
           .with(
-            version: '2.46.3',
+            version: '2.60.2',
             release: '1.1'
           )
       end
       it do
-        expect(chef_run).to install_package('jenkins').with(version: '2.46.3-1.1')
+        expect(chef_run).to install_package('jenkins').with(version: '2.60.2-1.1')
       end
       case p
       when CENTOS_6_OPTS

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -7,11 +7,11 @@ shared_examples_for 'jenkins_server' do
   end
 
   describe package('jenkins') do
-    it { should be_installed.with_version('2.46.3-1.1') }
+    it { should be_installed.with_version('2.60.2-1.1') }
   end
 
   describe command('yum versionlock') do
-    its(:stdout) { should match(/^0:jenkins-2.46.3-1.1.x86_64$/) }
+    its(:stdout) { should match(/^0:jenkins-2.60.2-1.1.x86_64$/) }
   end
 
   %w(80 443 8080).each do |p|
@@ -26,6 +26,6 @@ shared_examples_for 'jenkins_server' do
   end
 
   describe command('curl -k https://localhost/about/') do
-    its(:stdout) { should match(/Jenkins 2.46.3/) }
+    its(:stdout) { should match(/Jenkins 2.60.2/) }
   end
 end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -10,6 +10,10 @@ shared_examples_for 'jenkins_server' do
     it { should be_installed.with_version('2.46.3-1.1') }
   end
 
+  describe command('yum versionlock') do
+    its(:stdout) { should match(/^0:jenkins-2.46.3-1.1.x86_64$/) }
+  end
+
   %w(80 443 8080).each do |p|
     describe port(p) do
       it { should be_listening }


### PR DESCRIPTION
Other fixes included:

- Use yum-version-lock to ensure we don't accidentally upgrade jenkins

Something to keep in mind is that this is the first release which requires Java 8 to run according to the [Changelog](https://jenkins.io/changelog-stable/). I checked a while back and I'm pretty sure all of our clients are using Java 8 but it wouldn't hurt to double check.