### PR TITLE
Fix for #94

### DIFF
--- a/files/default/lib/packer_pipeline.rb
+++ b/files/default/lib/packer_pipeline.rb
@@ -31,7 +31,7 @@ class PackerPipeline
     dependent_templates = []
 
     # go to dir containing all images
-    Dir.chdir(ENV['PACKER_TEMPLATES_DIR'] || '/home/alfred/workspace')
+    Dir.chdir(ENV['PACKER_TEMPLATES_DIR'] || '/home/alfred/workspace/packer-templates')
 
     # Find if a shell script is referenced
     # iterate through images and look whether they refer to file


### PR DESCRIPTION
~Aims to~ Fixes the bug #94 in alliance with the latest commits on https://github.com/osuosl/packer-templates/pull/26

Since the `packer-templates` repo was not checked out on master, our payload processor never looked at them and always returned only the templates which were present in the PR and *not* the templates which were also affected by the changes in the PR (it's original purpose)

This makes it look at the right dir and along with the other changes to Jenkinsfile ensures that the find the right affected templates.

A latest result of this can be seen by comparing current [1] and old [2] CI packer-pipeline jobs output
[1] https://jenkins.osuosl.org/job/packer_pipeline/91/console
[2] https://jenkins.osuosl.org/job/packer_pipeline/60/console