### PR TITLE
Ratelimit and add a quiet period to packer_pipeline.

### DIFF
--- a/templates/default/packer_pipeline.config.xml.erb
+++ b/templates/default/packer_pipeline.config.xml.erb
@@ -21,6 +21,10 @@
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
+    <jenkins.branch.RateLimitBranchProperty_-JobPropertyImpl plugin="branch-api@2.0.8">
+      <durationName>hour</durationName>
+      <count>2</count>
+    </jenkins.branch.RateLimitBranchProperty_-JobPropertyImpl>
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers/>
     </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
@@ -46,5 +50,6 @@
     <lightweight>true</lightweight>
   </definition>
   <triggers/>
+  <quietPeriod>600</quietPeriod>
   <authToken><%= @trigger_token %></authToken>
 </flow-definition>


### PR DESCRIPTION
This will probably spare the master from being overwhelmed by the pipeline.

This will:
* Allow only 2 builds to be executed in an hour on the packer_pipeline. The packer pipeline's architecture is such that that the master waits on the nodes to complete and return output thus eating up multiple "run slots" on the master. Rate-limiting it to only 2 builds in an hour should mean we are leaving other run slots for other jobs on the master like the linter.

* Set a quiet period of 10 minutes. 
Jenkins puts it better
``
 For example, if your builds take a long time to execute, you may want to prevent multiple source control commits that are made at approximately the same time from triggering multiple builds. Enabling the quiet period would prevent a build from being started as soon as Jenkins discovers the first commit; this would give the developer the chance to push more commits which would be included in the build when it starts. This reduces the size of the queue, meaning that developers would get feedback faster for their series of commits, and the load on the Jenkins system would be reduced.
``
I am not sure if this new setting will really help, but it won't harm for sure.
