### PR TITLE
openstack client for pipeline nodes

### DIFF
--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -104,3 +104,14 @@ chef_gem 'openstack_taster' do
   clear_sources true
   action :install
 end
+
+# install openstack-cli as a python package if not already installed
+install_openstack_cli_package = %w(
+  /usr/local/bin/openstack
+  /usr/bin/openstack
+).none? { |ob| File.executable? ob }
+
+if install_openstack_cli_package
+  include_recipe 'poise-python'
+  python_package 'python-openstackclient'
+end

--- a/spec/unit/recipes/packer_pipeline_node.rb
+++ b/spec/unit/recipes/packer_pipeline_node.rb
@@ -33,6 +33,11 @@ describe 'osl-jenkins::packer_pipeline_node' do
         runner.converge(described_recipe)
       end
 
+      before do
+        # stub absence of openstack commandline tool
+        allow(File).to receive(:executable?).and_return(false)
+      end
+
       include_context 'common_stubs'
       include_context 'data_bag_stubs'
 
@@ -84,6 +89,26 @@ describe 'osl-jenkins::packer_pipeline_node' do
         expect(chef_run).to install_chef_gem('openstack_taster').with(
           options: '--no-user-install'
         )
+      end
+
+      it do
+        expect(chef_run).to install_python_package('python-openstackclient')
+      end
+    end
+
+    context 'when openstack client is already installed' do
+      cached(:chef_run) do
+        runner = ChefSpec::SoloRunner.new(p)
+        runner.converge(described_recipe)
+      end
+
+      include_context 'common_stubs'
+      include_context 'data_bag_stubs'
+
+      it do
+        # stub presence of openstack commandline tool
+        allow(File).to receive(:executable?).and_return(true)
+        expect(chef_run).to_not install_python_package('python-openstackclient')
       end
     end
   end

--- a/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
+++ b/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
@@ -55,3 +55,7 @@ describe file('/opt/chef/embedded/bin/openstack_taster') do
   it { should be_a_file }
   it { should be_executable }
 end
+
+describe command('openstack --version') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
+++ b/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
@@ -56,6 +56,6 @@ describe file('/opt/chef/embedded/bin/openstack_taster') do
   it { should be_executable }
 end
 
-describe command('openstack --version') do
+describe command("scl enable python27 'openstack --version'") do
   its(:exit_status) { should eq 0 }
 end


### PR DESCRIPTION
This installs the [python-openstackclient](https://pypi.python.org/pypi/python-openstackclient) package using `poise-python`, _if_ it is not already installed.
Hence it would require us to `scl-enable` python everytime we want to use it.