### PR TITLE
Set status on PR for packer-templates repo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Style/MutableConstant:
     - 'spec/spec_helper.rb'
 
 Metrics/AbcSize:
-  Max: 30
+  Max: 31.11
   Exclude:
     - 'libraries/default.rb'
 

--- a/files/default/bin/packer_pipeline.rb
+++ b/files/default/bin/packer_pipeline.rb
@@ -43,7 +43,7 @@ end
 if options[:final_results_file]
   if File.readable? options[:final_results_file]
     final_results = File.read(options[:final_results_file])
-    puts PackerPipeline.new.commit_status(final_results)
+    puts "We set GitHub status as #{PackerPipeline.new.commit_status(final_results)}"
     exit 0
   else
     puts "Final results file #{options[:final_results_file]} is not readable!"

--- a/files/default/bin/packer_pipeline.rb
+++ b/files/default/bin/packer_pipeline.rb
@@ -1,4 +1,66 @@
 #!/opt/chef/embedded/bin/ruby
 require_relative '../lib/packer_pipeline'
+require 'json'
+require 'optparse'
 
-puts PackerPipeline.start.to_json
+options = {}
+
+parser = OptionParser.new do |opts|
+  opts.banner = """
+        Usage: #{$0} -p PAYLOAD_JSON_FILE -f FINAL_RESULTS_FILE
+        You can either pass the PAYLOAD_JSON_FILE to process and begin the pipeline processing
+        OR the FINAL_RESULTS_FILE to send back to GitHub
+  """
+
+  opts.separator('')
+  opts.on('-p PAYLOAD_JSON_FILE',
+          '--payload_file PAYLOAD_JSON_FILE',
+          'Specify the JSON payload to process.') do |p|
+    options[:payload_json_file] = p
+  end
+
+  opts.on('-f FINAL_RESULTS_FILE',
+          '--final_results_file FINAL_RESULTS_FILE',
+          'Specify the JSON file containing the final results of pipeline processing.') do |f|
+    options[:final_results_file] = f
+  end
+
+  opts.on_tail('-h', '--help', 'Prints this help text') do
+    puts opts
+    exit
+  end
+end
+
+parser.parse! ARGV
+
+puts options
+
+if !options.key?(:payload_json_file) &&
+   !options.key?(:final_results_file)
+
+  puts "Either you must pass the PAYLOAD_JSON_FILE or the FINAL_RESULTS_FILE!"
+  exit 1
+end
+
+
+if options[:final_results_file]
+  if File.readable? options[:final_results_file]
+    final_results = JSON.parse(File.read(options[:final_results_file]))
+    PackerPipeline.new().set_commit_status(final_results)
+    exit 0
+  else
+    puts "Final results file #{options[:final_results_file]} is not readable!"
+    exit 2
+  end
+end
+
+if options[:payload_json_file]
+  if File.readable? options[:payload_json_file]
+    payload = JSON.parse(File.read(options[:payload_json_file]))
+    PackerPipeline.new().process_payload(payload).to_json
+    exit 0
+  else
+    puts "Payload JSON file #{options[:payload_json_file]} is not readable!"
+    exit 2
+  end
+end

--- a/files/default/bin/packer_pipeline.rb
+++ b/files/default/bin/packer_pipeline.rb
@@ -6,11 +6,11 @@ require 'optparse'
 options = {}
 
 parser = OptionParser.new do |opts|
-  opts.banner = """
-        Usage: #{$0} -p PAYLOAD_JSON_FILE -f FINAL_RESULTS_FILE
+  opts.banner = "
+        Usage: #{$PROGRAM_NAME} -p PAYLOAD_JSON_FILE -f FINAL_RESULTS_FILE
         You can either pass the PAYLOAD_JSON_FILE to process and begin the pipeline processing
         OR the FINAL_RESULTS_FILE to send back to GitHub
-  """
+  "
 
   opts.separator('')
   opts.on('-p PAYLOAD_JSON_FILE',
@@ -33,20 +33,17 @@ end
 
 parser.parse! ARGV
 
-puts options
-
 if !options.key?(:payload_json_file) &&
    !options.key?(:final_results_file)
 
-  puts "Either you must pass the PAYLOAD_JSON_FILE or the FINAL_RESULTS_FILE!"
+  puts 'Either you must pass the PAYLOAD_JSON_FILE or the FINAL_RESULTS_FILE!'
   exit 1
 end
 
-
 if options[:final_results_file]
   if File.readable? options[:final_results_file]
-    final_results = JSON.parse(File.read(options[:final_results_file]))
-    PackerPipeline.new().set_commit_status(final_results)
+    final_results = File.read(options[:final_results_file])
+    puts PackerPipeline.new.commit_status(final_results)
     exit 0
   else
     puts "Final results file #{options[:final_results_file]} is not readable!"
@@ -56,8 +53,8 @@ end
 
 if options[:payload_json_file]
   if File.readable? options[:payload_json_file]
-    payload = JSON.parse(File.read(options[:payload_json_file]))
-    PackerPipeline.new().process_payload(payload).to_json
+    payload = File.read(options[:payload_json_file])
+    puts PackerPipeline.new.process_payload(payload).to_json
     exit 0
   else
     puts "Payload JSON file #{options[:payload_json_file]} is not readable!"

--- a/files/default/lib/packer_pipeline.rb
+++ b/files/default/lib/packer_pipeline.rb
@@ -13,12 +13,17 @@ Octokit.middleware = stack
 
 # Library to process github payload for Packer Template Pipeline
 class PackerPipeline
+
+  def self.new
+    @github = Octokit::Client.new(access_token: ENV['GITHUB_TOKEN'], auto_paginate: true)
+    @repo_path = 'osuosl/packer-templates'
+    self
+  end
+
   # find the changed files associated with the PR
   def self.changed_files(json)
-    github = Octokit::Client.new(access_token: ENV['GITHUB_TOKEN'], auto_paginate: true)
-    repo_path = json['repository']['full_name']
     issue_number = json['number']
-    github.pull_request_files(repo_path, issue_number)
+    @github.pull_request_files(@repo_path, issue_number)
   end
 
   # If file is a template, return it in an array.
@@ -61,15 +66,66 @@ class PackerPipeline
     dependent_templates
   end
 
-  def self.start
-    d = JSON.parse(STDIN.read)
+  # update status for the PR from the final_results given by the pipeline
+  # the final_results is a JSON hash containing all the templates that were processed.
+  def self.set_commit_status(final_results)
+    git_commit = ENV['GIT_COMMIT']
+    return unless git_commit
+
+    # we are processing a JSON array which looks liek
+    # {
+    #   'arch': {
+    #       'template_name' : {
+    #             'linter' : 0,
+    #             'builder': 0,
+    #             'deploy_test' : 0,
+    #             'taster' : 0,
+    #         }
+    #   }
+    # }
+
+    #TODO: make this point to the specific job's console output
+    target_url = 'https://jenkins.osuosl.org/job/packer_pipeline'
+
+    p final_results 
+
+    final_status = {}
+
+    final_results.keys.each do |arch|
+      final_results[arch].keys.each do |t|
+        #create a context array per template
+        final_status[t] = { options: {
+            context: t,
+            target_url: target_url,
+          }
+        }
+
+        final_results[arch][t].keys.each do |stage|
+          if final_results[arch][t][stage] != 0
+            final_status[t][:state] = 'failure'
+            final_status[t][:options][:description] = "#{stage} failed!"
+            break
+          end
+
+          final_status[t][:state] = 'success'
+          final_status[t][:options][:description] = "All passed! #{final_results[arch][t]}"
+        end
+      #set status
+      @github.create_status(@repo_path, git_commit, final_status[t][:state], final_status[t][:options])
+      end
+    end
+
+    puts "We set result as #{final_status}"
+  end
+
+  def self.process_payload(payload)
 
     # Iterate through all the changed files and get an array of affected templates.
     # find_dependent_templates always returns an array of strings, so I use
     # .reduce to stitch those arrays together by doing the + on arrays of dependent
     # templates for each script. Finally .uniq will ensure we don't get the same
     # template twice in the array
-    templates = PackerPipeline.changed_files(d).map do |f|
+    templates = PackerPipeline.changed_files(payload).map do |f|
       find_dependent_templates(f.filename)
     end.reduce(:+).uniq
 

--- a/files/default/lib/packer_pipeline.rb
+++ b/files/default/lib/packer_pipeline.rb
@@ -73,7 +73,7 @@ class PackerPipeline
 
     final_results = JSON.parse(final_results)
 
-    # we are processing a JSON array which looks liek
+    # we are processing a JSON array which looks like
     # {
     #   'arch': {
     #       'template_name' : {
@@ -93,12 +93,15 @@ class PackerPipeline
           options: {
             context: t,
             # TODO: make this point to the specific job's console output
-            target_url: 'https://jenkins.osuosl.org/job/packer_pipeline'
+            target_url: "#{ENV['BUILD_URL']}console"
           }
         }
 
+        # we will set the GitHub status based on the first stage that we encounter
+        # as failed. The Pipeline automatically ignores a template once it has
+        # failed a previous stage, so we do it this way.
         final_results[arch][t].keys.each do |stage|
-          if final_results[arch][t][stage] != 0
+          if final_results[arch][t][stage].to_i != 0
             final_status[t][:state] = 'failure'
             final_status[t][:options][:description] = "#{stage} failed!"
             break
@@ -111,7 +114,7 @@ class PackerPipeline
         @github.create_status(@repo_path, git_commit, final_status[t][:state], final_status[t][:options])
       end
     end
-    puts "We set GitHub status as #{final_status}"
+    final_status
   end
 
   def self.process_payload(payload)

--- a/spec/fixtures/final_results_multiple_templates.json
+++ b/spec/fixtures/final_results_multiple_templates.json
@@ -1,0 +1,1 @@
+{"x86_64":{"centos-7.3-x86_64-mitaka-aio-openstack.json":{"linter":0,"builder":1},"centos-7.3-x86_64-openstack.json":{"linter":0,"builder":0,"deploy_test":0,"taster":0}}}

--- a/spec/fixtures/final_results_single_template.json
+++ b/spec/fixtures/final_results_single_template.json
@@ -1,0 +1,1 @@
+{"x86_64":{"centos-7.3-x86_64-mitaka-aio-openstack.json":{"linter":0,"builder":1}}}

--- a/spec/webhooks/packer_pipeline_spec.rb
+++ b/spec/webhooks/packer_pipeline_spec.rb
@@ -38,7 +38,7 @@ describe PackerPipeline do
     it 'finds single changed file' do
       response_body = [double('Sawyer::Resource', filename: 'centos-7.3-x86_64-openstack.json')]
       allow(github_mock).to receive(:pull_request_files).with('osuosl/packer-templates', 16).and_return(response_body)
-      files = PackerPipeline.changed_files(open_json('sync_packer_templates.json'))
+      files = PackerPipeline.new.changed_files(open_json('sync_packer_templates.json'))
       expect(files.first.filename).to match(/centos-7.3-x86_64-openstack.json/)
     end
     it 'finds multiple changed files' do
@@ -47,7 +47,7 @@ describe PackerPipeline do
         double('Sawyer::Resource', filename: 'centos-7.2-ppc64-openstack.json')
       ]
       allow(github_mock).to receive(:pull_request_files).with('osuosl/packer-templates', 16).and_return(response_body)
-      files = PackerPipeline.changed_files(open_json('sync_packer_templates.json'))
+      files = PackerPipeline.new.changed_files(open_json('sync_packer_templates.json'))
       expect(files[0].filename).to match(/centos-7.3-x86_64-openstack.json/)
       expect(files[1].filename).to match(/centos-7.2-ppc64-openstack.json/)
     end
@@ -60,25 +60,25 @@ describe PackerPipeline do
     end
     it 'returns just the template name when a template name is passed' do
       file = fixture_path('centos-7.2-ppc64-openstack.json')
-      expect(PackerPipeline.find_dependent_templates(file)).to match_array(['centos-7.2-ppc64-openstack.json'])
+      expect(PackerPipeline.new.find_dependent_templates(file)).to match_array(['centos-7.2-ppc64-openstack.json'])
     end
     it 'returns a template that uses a script' do
       file = fixture_path('osuosl.sh')
-      expect(PackerPipeline.find_dependent_templates(file)).to match_array(['centos-7.3-x86_64-openstack.json'])
+      expect(PackerPipeline.new.find_dependent_templates(file)).to match_array(['centos-7.3-x86_64-openstack.json'])
     end
     it 'returns templates that use a script' do
       file = fixture_path('openstack.sh')
-      expect(PackerPipeline.find_dependent_templates(file)).to match_array(
+      expect(PackerPipeline.new.find_dependent_templates(file)).to match_array(
         ['centos-7.3-x86_64-openstack.json', 'centos-7.2-ppc64-openstack.json']
       )
     end
     it 'returns nothing when a script is not used by any template' do
       file = fixture_path('this_script_does_not_exist_in_this_universe.sh')
-      expect(PackerPipeline.find_dependent_templates(file)).to match_array(nil)
+      expect(PackerPipeline.new.find_dependent_templates(file)).to match_array(nil)
     end
   end
 
-  context '#start' do
+  context '#process_payload' do
     let(:github_mock) { double('Octokit', commits: [], issues: [], same_options?: false, auto_paginate: true) }
     before :each do
       allow(Octokit::Client).to receive(:new) { github_mock }
@@ -89,22 +89,30 @@ describe PackerPipeline do
       file = fixture_path('osuosl.sh')
       response_body = [double('Sawyer::Resource', filename: file)]
       allow(github_mock).to receive(:pull_request_files).with('osuosl/packer-templates', 16).and_return(response_body)
-      allow(STDIN).to receive(:read).and_return(open_fixture('sync_packer_templates.json'))
-      expect { puts PackerPipeline.start.to_json }.to output(/16/).to_stdout
+      payload = open_fixture('sync_packer_templates.json')
+      expect { puts PackerPipeline.new.process_payload(payload).to_json }.to output(/16/).to_stdout
     end
     it 'ouputs the name of a template file' do
       file = fixture_path('centos-7.2-ppc64-openstack.json')
       response_body = [double('Sawyer::Resource', filename: file)]
       allow(github_mock).to receive(:pull_request_files).with('osuosl/packer-templates', 16).and_return(response_body)
-      allow(STDIN).to receive(:read).and_return(open_fixture('sync_packer_templates.json'))
-      expect { puts PackerPipeline.start.to_json }.to output(/centos-7.2-ppc64-openstack.json/).to_stdout
+
+      payload = open_fixture('sync_packer_templates.json')
+
+      expect do
+        puts PackerPipeline.new.process_payload(payload).to_json
+      end.to output(/centos-7.2-ppc64-openstack.json/).to_stdout
     end
     it 'finds a template that uses a script' do
       file = fixture_path('osuosl.sh')
       response_body = [double('Sawyer::Resource', filename: file)]
       allow(github_mock).to receive(:pull_request_files).with('osuosl/packer-templates', 16).and_return(response_body)
-      allow(STDIN).to receive(:read).and_return(open_fixture('sync_packer_templates.json'))
-      expect { puts PackerPipeline.start.to_json }.to output(/centos-7.3-x86_64-openstack.json/).to_stdout
+
+      payload = open_fixture('sync_packer_templates.json')
+
+      expect do
+        puts PackerPipeline.new.process_payload(payload).to_json
+      end.to output(/centos-7.3-x86_64-openstack.json/).to_stdout
     end
     it 'outputs name of template file and finds a template that uses a script' do
       template = fixture_path('centos-7.2-ppc64-openstack.json')
@@ -114,9 +122,16 @@ describe PackerPipeline do
         double('Sawyer::Resource', filename: script)
       ]
       allow(github_mock).to receive(:pull_request_files).with('osuosl/packer-templates', 16).and_return(response_body)
-      allow(STDIN).to receive(:read).and_return(open_fixture('sync_packer_templates.json'))
-      expect { puts PackerPipeline.start.to_json }.to output(/centos-7.3-x86_64-openstack.json/).to_stdout
-      expect { puts PackerPipeline.start.to_json }.to output(/centos-7.2-ppc64-openstack.json/).to_stdout
+
+      payload = open_fixture('sync_packer_templates.json')
+
+      expect do
+        puts PackerPipeline.new.process_payload(payload).to_json
+      end.to output(/centos-7.3-x86_64-openstack.json/).to_stdout
+
+      expect do
+        puts PackerPipeline.new.process_payload(payload).to_json
+      end.to output(/centos-7.2-ppc64-openstack.json/).to_stdout
     end
   end
 end


### PR DESCRIPTION
This also changes the original packer_pipeline ruby binary to accept a JSON file for either processing the GitHub payload or to set the status on the GitHub commit by processing the final results array created by the pipeline.

The status will be set as demonstrated on osuosl/packer-templates#29, (ignoring the template1 and template2)