### PR TITLE
Setup chefdk on packer-pipeline nodes

### DIFF
--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -29,6 +29,9 @@ include_recipe 'build-essential::default'
 include_recipe 'yum-qemu-ev::default'
 include_recipe 'base::kvm'
 
+# setup chefdk so that we have berks
+include_recipe 'base::chefdk'
+
 # Create directory for builds and other artifacts
 directory '/home/alfred/workspace' do
   owner 'alfred'

--- a/spec/unit/recipes/packer_pipeline_node.rb
+++ b/spec/unit/recipes/packer_pipeline_node.rb
@@ -94,6 +94,10 @@ describe 'osl-jenkins::packer_pipeline_node' do
       it do
         expect(chef_run).to install_python_package('python-openstackclient')
       end
+
+      it do
+        expect(chef_run).to install_package('chefdk')
+      end
     end
 
     context 'when openstack client is already installed' do

--- a/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
+++ b/test/integration/packer_pipeline_node/serverspec/packer_pipeline_node_spec.rb
@@ -59,3 +59,7 @@ end
 describe command("scl enable python27 'openstack --version'") do
   its(:exit_status) { should eq 0 }
 end
+
+describe command('berks version') do
+  its(:exit_status) { should eq 0 }
+end


### PR DESCRIPTION
This is required to provide `berks` and other utilities which are used in building packer images which require chef provisioning like the mitaka-aio and mitaka-identity images