### PR TITLE
Remove testing env from default env

### DIFF
--- a/recipes/jenkins1.rb
+++ b/recipes/jenkins1.rb
@@ -24,7 +24,6 @@ node.default['osl-jenkins']['cookbook_uploader'].tap do |conf|
     phase_out_nginx
     phpbb
     production
-    testing
     workstation
   )
   conf['org'] = 'osuosl-cookbooks'


### PR DESCRIPTION
As of https://github.com/osuosl/chef-repo/commit/9e8397df32bab644fcceb5a167fa7a96f3269e13, the testing environment no longer exists in chef-repo, which means trying to run a bump command with the default env's fails, such as [here](https://github.com/osuosl-cookbooks/proj-phpbb/pull/204).