### PR TITLE
Use openstack_newton instead of openstack_mitaka for default chef env…

### DIFF
--- a/recipes/jenkins1.rb
+++ b/recipes/jenkins1.rb
@@ -20,7 +20,7 @@ node.default['osl-jenkins']['cookbook_uploader'].tap do |conf|
   conf['chef_repo'] = 'osuosl/chef-repo'
   conf['default_environments'] = %w(
     gwm
-    openstack_mitaka
+    openstack_newton
     phase_out_nginx
     phpbb
     production


### PR DESCRIPTION
…ironments

This is in preparation to remove the openstack_newton environment