### PR TITLE
Bump github-api to 1.90 to work around issue with their API

### DIFF
--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -29,7 +29,7 @@ default['osl-jenkins']['plugins'] = %w(
   git:3.5.1
   git-client:2.5.0
   github:1.26.2
-  github-api:1.86
+  github-api:1.90
   github-branch-source:2.2.3
   github-oauth:0.22.3
   github-organization-folder:1.6

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -69,7 +69,7 @@ node.default['osl-jenkins']['restart_plugins'] = %w(
   git-client:2.5.0
   git:3.5.1
   git-server:1.7
-  github-api:1.86
+  github-api:1.90
   github:1.27.0
   github-branch-source:2.2.3
   github-oauth:0.27

--- a/spec/unit/recipes/plugins_spec.rb
+++ b/spec/unit/recipes/plugins_spec.rb
@@ -46,7 +46,7 @@ describe 'osl-jenkins::plugins' do
         git:3.5.1
         git-client:2.5.0
         github:1.26.2
-        github-api:1.86
+        github-api:1.90
         github-branch-source:2.2.3
         github-oauth:0.22.3
         github-organization-folder:1.6

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -51,7 +51,7 @@ describe 'osl-jenkins::powerci' do
         emailext-template:1.0
         embeddable-build-status:1.9
         git-client:2.5.0
-        github-api:1.86
+        github-api:1.90
         github-oauth:0.27
         job-restrictions:0.6
         matrix-project:1.10

--- a/test/integration/plugins/serverspec/plugins_spec.rb
+++ b/test/integration/plugins/serverspec/plugins_spec.rb
@@ -29,7 +29,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     git:3.5.1
     git-client:2.5.0
     github:1.26.2
-    github-api:1.86
+    github-api:1.90
     github-branch-source:2.2.3
     github-oauth:0.22.3
     github-organization-folder:1.6

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -22,7 +22,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     git:3.5.1
     pipeline-stage-tags-metadata:1.1.3
     workflow-scm-step:2.4
-    github-api:1.86
+    github-api:1.90
     workflow-cps-global-lib:2.8
     openstack-cloud:2.22
     cloudbees-folder:6.0.3


### PR DESCRIPTION
This updates github-api to version 1.90 this resolves this issue [1] that we're
currently hitting with our Jenkins servers.

[1] https://issues.jenkins-ci.org/browse/JENKINS-47601