### PR TITLE
Adjust timeouts for packer jobs

### DIFF
--- a/templates/default/packer_pipeline.config.xml.erb
+++ b/templates/default/packer_pipeline.config.xml.erb
@@ -23,7 +23,7 @@
     </hudson.model.ParametersDefinitionProperty>
     <jenkins.branch.RateLimitBranchProperty_-JobPropertyImpl plugin="branch-api@2.0.8">
       <durationName>hour</durationName>
-      <count>2</count>
+      <count>4</count>
     </jenkins.branch.RateLimitBranchProperty_-JobPropertyImpl>
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers/>
@@ -51,6 +51,5 @@
     <lightweight>true</lightweight>
   </definition>
   <triggers/>
-  <quietPeriod>600</quietPeriod>
   <authToken><%= @trigger_token %></authToken>
 </flow-definition>


### PR DESCRIPTION
There's no need to set the quiet period for this job. In addition, let's
increase the amount of jobs we can run from 2 per hour to 4 per hour. I think
this is a more sensible configuration for now.