### PR TITLE
Disable throttle for packer builds

### DIFF
--- a/templates/default/packer_pipeline.config.xml.erb
+++ b/templates/default/packer_pipeline.config.xml.erb
@@ -21,10 +21,6 @@
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
-    <jenkins.branch.RateLimitBranchProperty_-JobPropertyImpl plugin="branch-api@2.0.8">
-      <durationName>hour</durationName>
-      <count>4</count>
-    </jenkins.branch.RateLimitBranchProperty_-JobPropertyImpl>
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers/>
     </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>


### PR DESCRIPTION
I don't think this is really needed anymore and it's causing more problems than
helping.