### PR TITLE
Bump to jenkins-2.89.4

### DIFF
--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -19,7 +19,7 @@ default['osl-jenkins']['plugins'] = %w(
   cloudbees-folder:6.0.3
   command-launcher:1.2
   conditional-buildstep:1.3.1
-  credentials-binding:1.13
+  credentials-binding:1.15
   cvs:2.12
   display-url-api:1.1.1
   docker-commons:1.8
@@ -43,7 +43,7 @@ default['osl-jenkins']['plugins'] = %w(
   jackson2-api:2.7.3
   javadoc:1.3
   jquery-detached:1.2.1
-  junit:1.20
+  junit:1.24
   ldap:1.12
   mailer:1.20
   mapdb-api:1.0.6.0
@@ -69,7 +69,7 @@ default['osl-jenkins']['plugins'] = %w(
   pipeline-utility-steps:1.4.0
   plain-credentials:1.4
   run-condition:1.0
-  scm-api:2.2.0
+  scm-api:2.2.6
   script-security:1.39
   ssh-agent:1.15
   ssh-slaves:1.16
@@ -89,6 +89,6 @@ default['osl-jenkins']['plugins'] = %w(
   workflow-multibranch:2.14
   workflow-scm-step:2.4
   workflow-step-api:2.14
-  workflow-support:2.17
+  workflow-support:2.18
   ws-cleanup:0.28
 )

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -20,7 +20,7 @@
 # Don't automatically update jenkins
 node.override['yum-cron']['yum_parameter'] = '-x jenkins'
 
-node.default['jenkins']['master']['version'] = '2.89.3-1.1'
+node.default['jenkins']['master']['version'] = '2.89.4-1.1'
 node.default['jenkins']['master']['listen_address'] = '127.0.0.1'
 
 node.default['java']['jdk_version'] = '8'

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -52,17 +52,17 @@ node.default['osl-jenkins']['restart_plugins'] = %w(
   structs:1.10
   display-url-api:2.0
   cloudbees-folder:6.0.3
-  scm-api:2.2.0
+  scm-api:2.2.6
   branch-api:2.0.8
   script-security:1.39
   workflow-step-api:2.14
   workflow-scm-step:2.4
   workflow-api:2.25
-  workflow-support:2.17
+  workflow-support:2.18
   workflow-cps:2.39
   workflow-job:2.10
   workflow-multibranch:2.14
-  junit:1.20
+  junit:1.24
   matrix-project:1.10
   mailer:1.20
   jackson2-api:2.7.3
@@ -91,7 +91,7 @@ node.default['osl-jenkins']['plugins'] = %w(
   workflow-cps-global-lib:2.8
   bouncycastle-api:2.16.1
   handlebars:1.1.1
-  credentials-binding:1.13
+  credentials-binding:1.15
   email-ext:2.57.2
   pipeline-milestone-step:1.3.1
   pipeline-rest-api:2.6

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -13,12 +13,12 @@ describe 'osl-jenkins::master' do
       it do
         expect(chef_run).to add_yum_version_lock('jenkins')
           .with(
-            version: '2.89.3',
+            version: '2.89.4',
             release: '1.1'
           )
       end
       it do
-        expect(chef_run).to install_package('jenkins').with(version: '2.89.3-1.1', flush_cache: { before: true })
+        expect(chef_run).to install_package('jenkins').with(version: '2.89.4-1.1', flush_cache: { before: true })
       end
       case p
       when CENTOS_6_OPTS

--- a/spec/unit/recipes/plugins_spec.rb
+++ b/spec/unit/recipes/plugins_spec.rb
@@ -36,7 +36,7 @@ describe 'osl-jenkins::plugins' do
         cloudbees-folder:6.0.3
         command-launcher:1.2
         conditional-buildstep:1.3.1
-        credentials-binding:1.13
+        credentials-binding:1.15
         cvs:2.12
         display-url-api:1.1.1
         docker-commons:1.8
@@ -60,7 +60,7 @@ describe 'osl-jenkins::plugins' do
         jackson2-api:2.7.3
         javadoc:1.3
         jquery-detached:1.2.1
-        junit:1.20
+        junit:1.24
         ldap:1.12
         mailer:1.20
         mapdb-api:1.0.6.0
@@ -86,7 +86,7 @@ describe 'osl-jenkins::plugins' do
         pipeline-utility-steps:1.4.0
         plain-credentials:1.4
         run-condition:1.0
-        scm-api:2.2.0
+        scm-api:2.2.6
         script-security:1.39
         ssh-agent:1.15
         ssh-slaves:1.16
@@ -106,7 +106,7 @@ describe 'osl-jenkins::plugins' do
         workflow-multibranch:2.14
         workflow-scm-step:2.4
         workflow-step-api:2.14
-        workflow-support:2.17
+        workflow-support:2.18
         ws-cleanup:0.28
       ).each do |plugins_version|
         plugin, version = plugins_version.split(':')

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -62,7 +62,7 @@ describe 'osl-jenkins::powerci' do
         copy-to-slave:1.4.4
         workflow-step-api:2.14
         workflow-api:2.25
-        workflow-support:2.17
+        workflow-support:2.18
         workflow-durable-task-step:2.18
       ).each do |plugins_version|
         plugin, version = plugins_version.split(':')

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -7,11 +7,11 @@ shared_examples_for 'jenkins_server' do
   end
 
   describe package('jenkins') do
-    it { should be_installed.with_version('2.89.3-1.1') }
+    it { should be_installed.with_version('2.89.4-1.1') }
   end
 
   describe command('yum versionlock') do
-    its(:stdout) { should match(/^0:jenkins-2.89.3-1.1.x86_64$/) }
+    its(:stdout) { should match(/^0:jenkins-2.89.4-1.1.x86_64$/) }
   end
 
   %w(80 443 8080).each do |p|
@@ -26,6 +26,6 @@ shared_examples_for 'jenkins_server' do
   end
 
   describe command('curl -k https://localhost/about/') do
-    its(:stdout) { should match(/Jenkins 2.89.3/) }
+    its(:stdout) { should match(/Jenkins 2.89.4/) }
   end
 end

--- a/test/integration/plugins/serverspec/plugins_spec.rb
+++ b/test/integration/plugins/serverspec/plugins_spec.rb
@@ -19,7 +19,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     command-launcher:1.2
     conditional-buildstep:1.3.1
     credentials:2.1.13
-    credentials-binding:1.13
+    credentials-binding:1.15
     cvs:2.12
     display-url-api:1.1.1
     docker-commons:1.8
@@ -43,7 +43,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     jackson2-api:2.7.3
     javadoc:1.3
     jquery-detached:1.2.1
-    junit:1.20
+    junit:1.24
     ldap:1.12
     mailer:1.20
     mapdb-api:1.0.6.0
@@ -69,7 +69,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     pipeline-utility-steps:1.4.0
     plain-credentials:1.4
     run-condition:1.0
-    scm-api:2.2.0
+    scm-api:2.2.6
     script-security:1.39
     ssh-agent:1.15
     ssh-credentials:1.13
@@ -90,7 +90,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     workflow-multibranch:2.14
     workflow-scm-step:2.4
     workflow-step-api:2.14
-    workflow-support:2.17
+    workflow-support:2.18
     ws-cleanup:0.28
   ).each do |plugins_version|
     plugin, version = plugins_version.split(':')

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -26,13 +26,13 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     workflow-cps-global-lib:2.8
     openstack-cloud:2.22
     cloudbees-folder:6.0.3
-    junit:1.20
+    junit:1.24
     bouncycastle-api:2.16.1
     display-url-api:2.0
     matrix-project:1.10
     config-file-provider:2.16.2
     handlebars:1.1.1
-    credentials-binding:1.13
+    credentials-binding:1.15
     workflow-cps:2.39
     workflow-job:2.10
     email-ext:2.57.2
@@ -46,7 +46,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     pipeline-input-step:2.8
     momentjs:1.1.1
     ssh-credentials:1.13
-    workflow-support:2.17
+    workflow-support:2.18
     pipeline-build-step:2.5.1
     matrix-auth:1.5
     workflow-multibranch:2.14
@@ -70,7 +70,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     pipeline-model-api:1.1.3
     pipeline-stage-step:2.2
     durable-task:1.17
-    scm-api:2.2.0
+    scm-api:2.2.6
     cloud-stats:0.11
     plain-credentials:1.4
     github-oauth:0.27


### PR DESCRIPTION
Also do the following security updates on the plugins:

- credentials-binding
- junit
- scm-api
- workflow-support