### PR TITLE
Update to jenkins-2.107.2

### DIFF
--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -23,15 +23,15 @@ default['osl-jenkins']['plugins'] = %w(
   conditional-buildstep:1.3.1
   credentials-binding:1.15
   cvs:2.12
-  display-url-api:1.1.1
+  display-url-api:2.2.0
   docker-commons:1.8
   docker-workflow:1.10
   durable-task:1.17
   external-monitor-job:1.4
-  ghprb:1.36.1
+  ghprb:1.40.0
   git:3.8.0
   git-client:2.7.1
-  github:1.26.2
+  github:1.29.0
   github-api:1.90
   github-branch-source:2.2.3
   github-oauth:0.22.3
@@ -48,10 +48,10 @@ default['osl-jenkins']['plugins'] = %w(
   jsch:0.1.54.2
   junit:1.24
   ldap:1.12
-  mailer:1.20
+  mailer:1.21
   mapdb-api:1.0.6.0
   matrix-auth:1.5
-  matrix-project:1.7.1
+  matrix-project:1.13
   maven-plugin:2.14
   momentjs:1.1.1
   pam-auth:1.2

--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -87,7 +87,7 @@ default['osl-jenkins']['plugins'] = %w(
   workflow-cps:2.39
   workflow-cps-global-lib:2.7
   workflow-durable-task-step:2.18
-  workflow-job:2.10
+  workflow-job:2.11
   workflow-multibranch:2.14
   workflow-scm-step:2.4
   workflow-step-api:2.14

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -63,7 +63,7 @@ node.default['osl-jenkins']['plugins'] = %w(
   docker-plugin:1.1.3
   docker-workflow:1.15.1
   durable-task:1.17
-  email-ext:2.57.2
+  email-ext:2.62
   emailext-template:1.0
   embeddable-build-status:1.9
   git:3.8.0
@@ -109,7 +109,7 @@ node.default['osl-jenkins']['plugins'] = %w(
   workflow-cps:2.39
   workflow-cps-global-lib:2.8
   workflow-durable-task-step:2.18
-  workflow-job:2.10
+  workflow-job:2.11
   workflow-multibranch:2.14
   workflow-scm-step:2.4
   workflow-step-api:2.14

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -45,6 +45,7 @@ end
 
 node.default['osl-jenkins']['plugins'] = %w(
   ace-editor:1.1
+  apache-httpcomponents-client-4-api:4.5.3-2.1
   authentication-tokens:1.3
   bouncycastle-api:2.16.2
   branch-api:2.0.8
@@ -55,7 +56,7 @@ node.default['osl-jenkins']['plugins'] = %w(
   command-launcher:1.2
   config-file-provider:2.16.2
   credentials-binding:1.15
-  display-url-api:2.0
+  display-url-api:2.2.0
   docker-build-publish:1.3.2
   docker-commons:1.11
   docker-java-api:3.0.14
@@ -65,9 +66,9 @@ node.default['osl-jenkins']['plugins'] = %w(
   email-ext:2.57.2
   emailext-template:1.0
   embeddable-build-status:1.9
-  git:3.5.1
-  git-client:2.5.0
-  github:1.27.0
+  git:3.8.0
+  git-client:2.7.1
+  github:1.29.0
   github-api:1.90
   github-branch-source:2.2.3
   github-oauth:0.27
@@ -77,12 +78,12 @@ node.default['osl-jenkins']['plugins'] = %w(
   jackson2-api:2.7.3
   job-restrictions:0.6
   jquery-detached:1.2.1
+  jsch:0.1.54.2
   junit:1.24
-  mailer:1.20
+  mailer:1.21
   matrix-auth:1.5
-  matrix-project:1.10
+  matrix-project:1.13
   momentjs:1.1.1
-  openstack-cloud:2.22
   pipeline-build-step:2.5.1
   pipeline-graph-analysis:1.3
   pipeline-input-step:2.8

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -20,7 +20,7 @@
 # Don't automatically update jenkins
 node.override['yum-cron']['yum_parameter'] = '-x jenkins'
 
-node.default['jenkins']['master']['version'] = '2.89.4-1.1'
+node.default['jenkins']['master']['version'] = '2.107.2-1.1'
 node.default['jenkins']['master']['listen_address'] = '127.0.0.1'
 
 node.default['java']['jdk_version'] = '8'

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -63,7 +63,7 @@ node.default['osl-jenkins']['plugins'] = %w(
   docker-plugin:1.1.3
   docker-workflow:1.15.1
   durable-task:1.17
-  email-ext:2.57.2
+  email-ext:2.62
   emailext-template:1.0
   embeddable-build-status:1.9
   git:3.8.0
@@ -110,7 +110,7 @@ node.default['osl-jenkins']['plugins'] = %w(
   workflow-cps:2.39
   workflow-cps-global-lib:2.8
   workflow-durable-task-step:2.18
-  workflow-job:2.10
+  workflow-job:2.11
   workflow-multibranch:2.14
   workflow-scm-step:2.4
   workflow-step-api:2.14

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -56,7 +56,7 @@ node.default['osl-jenkins']['plugins'] = %w(
   command-launcher:1.2
   config-file-provider:2.16.2
   credentials-binding:1.15
-  display-url-api:2.0
+  display-url-api:2.2.0
   docker-build-publish:1.3.2
   docker-commons:1.11
   docker-java-api:3.0.14
@@ -68,7 +68,7 @@ node.default['osl-jenkins']['plugins'] = %w(
   embeddable-build-status:1.9
   git:3.8.0
   git-client:2.7.1
-  github:1.27.0
+  github:1.29.0
   github-api:1.90
   github-branch-source:2.2.3
   github-oauth:0.27
@@ -80,9 +80,9 @@ node.default['osl-jenkins']['plugins'] = %w(
   jquery-detached:1.2.1
   jsch:0.1.54.2
   junit:1.24
-  mailer:1.20
+  mailer:1.21
   matrix-auth:1.5
-  matrix-project:1.10
+  matrix-project:1.13
   momentjs:1.1.1
   openstack-cloud:2.22
   pipeline-build-step:2.5.1

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -56,7 +56,7 @@ describe 'osl-jenkins::ibmz_ci' do
         docker-plugin:1.1.3
         docker-build-publish:1.3.2
         durable-task:1.17
-        email-ext:2.57.2
+        email-ext:2.62
         emailext-template:1.0
         embeddable-build-status:1.9
         git:3.8.0
@@ -72,6 +72,7 @@ describe 'osl-jenkins::ibmz_ci' do
         resource-disposer:0.6
         workflow-step-api:2.14
         workflow-api:2.25
+        workflow-job:2.11
         workflow-support:2.18
         workflow-durable-task-step:2.18
         command-launcher:1.2

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -46,9 +46,11 @@ describe 'osl-jenkins::ibmz_ci' do
         expect { chef_run }.to_not raise_error
       end
       %w(
+        apache-httpcomponents-client-4-api:4.5.3-2.1
         build-monitor-plugin:1.11+build.201701152243
         cloud-stats:0.11
         config-file-provider:2.16.2
+        display-url-api:2.2.0
         docker-commons:1.11
         docker-java-api:3.0.14
         docker-plugin:1.1.3
@@ -57,12 +59,15 @@ describe 'osl-jenkins::ibmz_ci' do
         email-ext:2.57.2
         emailext-template:1.0
         embeddable-build-status:1.9
-        git-client:2.5.0
+        git:3.8.0
+        git-client:2.7.1
+        github:1.29.0
         github-api:1.90
         github-oauth:0.27
         job-restrictions:0.6
-        matrix-project:1.10
-        openstack-cloud:2.22
+        jsch:0.1.54.2
+        mailer:1.21
+        matrix-project:1.13
         pipeline-multibranch-defaults:1.1
         resource-disposer:0.6
         workflow-step-api:2.14

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -13,12 +13,12 @@ describe 'osl-jenkins::master' do
       it do
         expect(chef_run).to add_yum_version_lock('jenkins')
           .with(
-            version: '2.89.4',
+            version: '2.107.2',
             release: '1.1'
           )
       end
       it do
-        expect(chef_run).to install_package('jenkins').with(version: '2.89.4-1.1', flush_cache: { before: true })
+        expect(chef_run).to install_package('jenkins').with(version: '2.107.2-1.1', flush_cache: { before: true })
       end
       case p
       when CENTOS_6_OPTS

--- a/spec/unit/recipes/plugins_spec.rb
+++ b/spec/unit/recipes/plugins_spec.rb
@@ -66,15 +66,15 @@ describe 'osl-jenkins::plugins' do
         conditional-buildstep:1.3.1
         credentials-binding:1.15
         cvs:2.12
-        display-url-api:1.1.1
+        display-url-api:2.2.0
         docker-commons:1.8
         docker-workflow:1.10
         durable-task:1.17
         external-monitor-job:1.4
-        ghprb:1.36.1
+        ghprb:1.40.0
         git:3.8.0
         git-client:2.7.1
-        github:1.26.2
+        github:1.29.0
         github-api:1.90
         github-branch-source:2.2.3
         github-oauth:0.22.3
@@ -91,10 +91,10 @@ describe 'osl-jenkins::plugins' do
         jsch:0.1.54.2
         junit:1.24
         ldap:1.12
-        mailer:1.20
+        mailer:1.21
         mapdb-api:1.0.6.0
         matrix-auth:1.5
-        matrix-project:1.7.1
+        matrix-project:1.13
         maven-plugin:2.14
         momentjs:1.1.1
         pam-auth:1.2

--- a/spec/unit/recipes/plugins_spec.rb
+++ b/spec/unit/recipes/plugins_spec.rb
@@ -130,7 +130,7 @@ describe 'osl-jenkins::plugins' do
         workflow-cps:2.39
         workflow-cps-global-lib:2.7
         workflow-durable-task-step:2.18
-        workflow-job:2.10
+        workflow-job:2.11
         workflow-multibranch:2.14
         workflow-scm-step:2.4
         workflow-step-api:2.14

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -59,7 +59,7 @@ describe 'osl-jenkins::powerci' do
         docker-plugin:1.1.3
         docker-build-publish:1.3.2
         durable-task:1.17
-        email-ext:2.57.2
+        email-ext:2.62
         emailext-template:1.0
         embeddable-build-status:1.9
         git:3.8.0
@@ -81,6 +81,7 @@ describe 'osl-jenkins::powerci' do
         build-token-root:1.4
         workflow-step-api:2.14
         workflow-support:2.18
+        workflow-job:2.11
       ).each do |plugins_version|
         plugin, version = plugins_version.split(':')
         it do

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -53,6 +53,7 @@ describe 'osl-jenkins::powerci' do
         config-file-provider:2.16.2
         copy-to-slave:1.4.4
         credentials:2.1.16
+        display-url-api:2.2.0
         docker-commons:1.11
         docker-java-api:3.0.14
         docker-plugin:1.1.3
@@ -63,11 +64,13 @@ describe 'osl-jenkins::powerci' do
         embeddable-build-status:1.9
         git:3.8.0
         git-client:2.7.1
+        github:1.29.0
         github-api:1.90
         github-oauth:0.27
         job-restrictions:0.6
         jsch:0.1.54.2
-        matrix-project:1.10
+        mailer:1.21
+        matrix-project:1.13
         openstack-cloud:2.22
         pipeline-multibranch-defaults:1.1
         resource-disposer:0.6

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -31,11 +31,11 @@ shared_examples_for 'jenkins_server' do
   end
 
   describe package('jenkins') do
-    it { should be_installed.with_version('2.89.4-1.1') }
+    it { should be_installed.with_version('2.107.2-1.1') }
   end
 
   describe command('yum versionlock') do
-    its(:stdout) { should match(/^0:jenkins-2.89.4-1.1.x86_64$/) }
+    its(:stdout) { should match(/^0:jenkins-2.107.2-1.1.x86_64$/) }
   end
 
   %w(80 443 8080).each do |p|
@@ -50,6 +50,6 @@ shared_examples_for 'jenkins_server' do
   end
 
   describe command('curl -k https://localhost/about/') do
-    its(:stdout) { should match(/Jenkins 2.89.4/) }
+    its(:stdout) { should match(/Jenkins 2.107.2/) }
   end
 end

--- a/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
+++ b/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
@@ -13,6 +13,7 @@ end
 describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localhost:8080/ list-plugins') do
   %w(
     ace-editor:1.1
+    apache-httpcomponents-client-4-api:4.5.3-2.1
     authentication-tokens:1.3
     bouncycastle-api:2.16.2
     branch-api:2.0.8
@@ -24,7 +25,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     config-file-provider:2.16.2
     credentials:2.1.16
     credentials-binding:1.15
-    display-url-api:2.0
+    display-url-api:2.2.0
     docker-build-publish:1.3.2
     docker-commons:1.11
     docker-java-api:3.0.14
@@ -34,9 +35,9 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     email-ext:2.57.2
     emailext-template:1.0
     embeddable-build-status:1.9
-    git:3.5.1
-    git-client:2.5.0
-    github:1.27.0
+    git:3.8.0
+    git-client:2.7.1
+    github:1.29.0
     github-api:1.90
     github-branch-source:2.2.3
     github-oauth:0.27
@@ -46,12 +47,12 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     jackson2-api:2.7.3
     job-restrictions:0.6
     jquery-detached:1.2.1
+    jsch:0.1.54.2
     junit:1.24
-    mailer:1.20
+    mailer:1.21
     matrix-auth:1.5
-    matrix-project:1.10
+    matrix-project:1.13
     momentjs:1.1.1
-    openstack-cloud:2.22
     pipeline-build-step:2.5.1
     pipeline-graph-analysis:1.3
     pipeline-input-step:2.8

--- a/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
+++ b/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
@@ -32,7 +32,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     docker-plugin:1.1.3
     docker-workflow:1.15.1
     durable-task:1.17
-    email-ext:2.57.2
+    email-ext:2.62
     emailext-template:1.0
     embeddable-build-status:1.9
     git:3.8.0
@@ -80,7 +80,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     workflow-cps:2.39
     workflow-cps-global-lib:2.8
     workflow-durable-task-step:2.18
-    workflow-job:2.10
+    workflow-job:2.11
     workflow-multibranch:2.14
     workflow-scm-step:2.4
     workflow-step-api:2.14

--- a/test/integration/plugins/serverspec/plugins_spec.rb
+++ b/test/integration/plugins/serverspec/plugins_spec.rb
@@ -30,15 +30,15 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     credentials:2.1.16
     credentials-binding:1.15
     cvs:2.12
-    display-url-api:1.1.1
+    display-url-api:2.2.0
     docker-commons:1.8
     docker-workflow:1.10
     durable-task:1.17
     external-monitor-job:1.4
-    ghprb:1.36.1
+    ghprb:1.40.0
     git:3.8.0
     git-client:2.7.1
-    github:1.26.2
+    github:1.29.0
     github-api:1.90
     github-branch-source:2.2.3
     github-oauth:0.22.3
@@ -55,10 +55,10 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     jsch:0.1.54.2
     junit:1.24
     ldap:1.12
-    mailer:1.20
+    mailer:1.21
     mapdb-api:1.0.6.0
     matrix-auth:1.5
-    matrix-project:1.7.1
+    matrix-project:1.13
     maven-plugin:2.14
     momentjs:1.1.1
     pam-auth:1.2

--- a/test/integration/plugins/serverspec/plugins_spec.rb
+++ b/test/integration/plugins/serverspec/plugins_spec.rb
@@ -96,7 +96,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     workflow-cps:2.39
     workflow-cps-global-lib:2.7
     workflow-durable-task-step:2.18
-    workflow-job:2.10
+    workflow-job:2.11
     workflow-multibranch:2.14
     workflow-scm-step:2.4
     workflow-step-api:2.14

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -17,7 +17,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     ssh-slaves:1.26
     resource-disposer:0.6
     pipeline-model-extensions:1.1.3
-    github:1.27.0
+    github:1.29.0
     structs:1.14
     emailext-template:1.0
     git:3.8.0
@@ -29,8 +29,8 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     cloudbees-folder:6.0.3
     junit:1.24
     bouncycastle-api:2.16.2
-    display-url-api:2.0
-    matrix-project:1.10
+    display-url-api:2.2.0
+    matrix-project:1.13
     config-file-provider:2.16.2
     handlebars:1.1.1
     credentials-binding:1.15
@@ -66,7 +66,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     docker-plugin:1.1.3
     pipeline-model-definition:1.1.3
     workflow-basic-steps:2.4
-    mailer:1.20
+    mailer:1.21
     credentials:2.1.16
     pipeline-model-api:1.1.3
     pipeline-stage-step:2.2

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -35,8 +35,8 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     handlebars:1.1.1
     credentials-binding:1.15
     workflow-cps:2.39
-    workflow-job:2.10
-    email-ext:2.57.2
+    workflow-job:2.11
+    email-ext:2.62
     pipeline-milestone-step:1.3.1
     icon-shim:2.0.3
     authentication-tokens:1.3


### PR DESCRIPTION
This also provides updates to the following plugins:

- display-url-api
- ghprb
- github
- mailer
- matrix-project

In addition, this pulls in some updates on powerci and ibmz-ci and also bringing
them into sync somewhat.