### PR TITLE
Add ccache volume to all docker instances for POWER/IBM-Z CI

### DIFF
--- a/libraries/docker.rb
+++ b/libraries/docker.rb
@@ -176,7 +176,7 @@ module OSLDocker
             '',     // dnsString
             '',     // network
             '',     // dockerCommand
-            '',     // volumesString
+            'ccache:/var/cache/ccache', // volumesString
             '',     // volumesFromString
             'JENKINS_SLAVE_SSH_PUBKEY=#{docker_public_key}', // environmentsString
             '',     // hostname


### PR DESCRIPTION
This automatically attaches a 'ccache' volume which is created in osl-docker for
each environment.