### PR TITLE
Always upgrade openstack_taster

### DIFF
--- a/attributes/packer_pipeline.rb
+++ b/attributes/packer_pipeline.rb
@@ -1,4 +1,3 @@
-default['osl-jenkins']['packer_pipeline']['openstack_taster_version'] = '1.0.2'
 default['osl-jenkins']['packer_pipeline'] = {
   'bin_path' => ::File.join(node['jenkins']['master']['home'], 'bin'),
   'lib_path' => ::File.join(node['jenkins']['master']['home'], 'lib'),

--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -109,8 +109,7 @@ end
 
 # install openstack_taster
 chef_gem 'openstack_taster' do
-  version node['osl-jenkins']['packer_pipeline']['openstack_taster_version']
   options '--no-user-install'
   clear_sources true
-  action :install
+  action :upgrade
 end

--- a/spec/unit/recipes/packer_pipeline_node_spec.rb
+++ b/spec/unit/recipes/packer_pipeline_node_spec.rb
@@ -69,8 +69,9 @@ describe 'osl-jenkins::packer_pipeline_node' do
       end
 
       it do
-        expect(chef_run).to install_chef_gem('openstack_taster').with(
-          options: '--no-user-install'
+        expect(chef_run).to upgrade_chef_gem('openstack_taster').with(
+          options: '--no-user-install',
+          clear_sources: true
         )
       end
     end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -5,27 +5,27 @@ require 'uri'
 
 set :backend, :exec
 
-# Copied from jenkins cookbook helper library
-begin
-  open('https://localhost/whoAmI/', ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
-rescue SocketError,
-       Errno::ECONNREFUSED,
-       Errno::ECONNRESET,
-       Errno::ENETUNREACH,
-       Errno::EADDRNOTAVAIL,
-       Timeout::Error,
-       OpenURI::HTTPError => e
-  # If authentication has been enabled, the server will return an HTTP
-  # 403. This is "OK", since it means that the server is actually
-  # ready to accept requests.
-  return if e.message =~ /^403/
-
-  puts "Jenkins is not accepting requests - #{e.message}"
-  sleep(0.5)
-  retry
-end
-
 shared_examples_for 'jenkins_server' do
+  # Copied from jenkins cookbook helper library
+  begin
+    open('https://localhost/whoAmI/', ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
+  rescue SocketError,
+         Errno::ECONNREFUSED,
+         Errno::ECONNRESET,
+         Errno::ENETUNREACH,
+         Errno::EADDRNOTAVAIL,
+         Timeout::Error,
+         OpenURI::HTTPError => e
+    # If authentication has been enabled, the server will return an HTTP
+    # 403. This is "OK", since it means that the server is actually
+    # ready to accept requests.
+    return if e.message =~ /^403/
+
+    puts "Jenkins is not accepting requests - #{e.message}"
+    sleep(0.5)
+    retry
+  end
+
   describe package('java-1.8.0-openjdk') do
     it { should be_installed }
   end


### PR DESCRIPTION
Since we control when new releases of openstack_taster, we don't need to lock
the version in the cookbook. This removes the requirement of bumping this
cookbook on every new release. It also ensures that it always uses the latest
version which it currently does even if you bump the version.

Also move jenkins checking code into the shared_examples block since that was breaking tests.