### PR TITLE
Disable OpenStack cloud in powerci due to potential issues

### DIFF
--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -177,7 +177,7 @@ docker_cloud =
     nil
   )
 
-openstack_cloud = add_openstack_cloud
+# openstack_cloud = add_openstack_cloud
 sge_cloud =
   add_sge_cloud(
     'CGRB-ubuntu',
@@ -201,9 +201,11 @@ jenkins_script 'Add Docker Cloud' do # ~FC005
   command docker_cloud
 end
 
-jenkins_script 'Add OpenStack Cloud' do
-  command openstack_cloud
-end
+# Disable code since we're not even using it and it may be causing other issues with Jenkins related to
+# https://support.osuosl.org/Ticket/Display.html?id=30194
+# jenkins_script 'Add OpenStack Cloud' do
+#   command openstack_cloud
+# end
 
 jenkins_script 'Add SGE Cloud' do
   command sge_cloud

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -159,9 +159,9 @@ describe 'osl-jenkins::powerci' do
         expect(chef_run).to execute_jenkins_script('Add GitHub OAuth config')
           .with(command: /\["testuser"\].each \{ nu -> user = BuildPermission.*/)
       end
-      it do
-        expect(chef_run).to execute_jenkins_script('Add OpenStack Cloud')
-      end
+      # it do
+      #   expect(chef_run).to execute_jenkins_script('Add OpenStack Cloud')
+      # end
       it do
         expect(chef_run).to execute_jenkins_script('Add SGE Cloud')
           .with(


### PR DESCRIPTION
We're not even currently using the OpenStack cloud instance (yet) and I'm
seeing errors such as the following in the logs:

```
SEVERE: A thread (OpenStack slave cleanup thread/5527) died unexpectedly due to an uncaught exception, this may leave y
our Jenkins in a bad way and is usually indicative of a bug in the code.
ConnectionException{status=0}
        at org.openstack4j.connectors.httpclient.HttpExecutorServiceImpl.invoke(HttpExecutorServiceImpl.java:60)
        at org.openstack4j.connectors.httpclient.HttpExecutorServiceImpl.execute(HttpExecutorServiceImpl.java:32)
        at org.openstack4j.core.transport.internal.HttpExecutor.execute(HttpExecutor.java:51)
        at org.openstack4j.openstack.internal.OSAuthenticator.authenticateV2(OSAuthenticator.java:122)
        at org.openstack4j.openstack.internal.OSAuthenticator.invoke(OSAuthenticator.java:52)
        at org.openstack4j.openstack.client.OSClientBuilder$ClientV2.authenticate(OSClientBuilder.java:117)
        at org.openstack4j.openstack.client.OSClientBuilder$ClientV2.authenticate(OSClientBuilder.java:79)
        at jenkins.plugins.openstack.compute.internal.Openstack.<init>(Openstack.java:119)
        at jenkins.plugins.openstack.compute.JCloudsCloud.getOpenstack(JCloudsCloud.java:456)
        at jenkins.plugins.openstack.compute.JCloudsCleanupThread.destroyServersOutOfScope(JCloudsCleanupThread.java:16
0)
        at jenkins.plugins.openstack.compute.JCloudsCleanupThread.execute(JCloudsCleanupThread.java:67)
        at hudson.model.AsyncPeriodicWork$1.run(AsyncPeriodicWork.java:101)
        at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.http.client.ClientProtocolException
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:186)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:107)
        at org.openstack4j.connectors.httpclient.HttpCommand.execute(HttpCommand.java:112)
        at org.openstack4j.connectors.httpclient.HttpExecutorServiceImpl.invokeRequest(HttpExecutorServiceImpl.java:65)
        at org.openstack4j.connectors.httpclient.HttpExecutorServiceImpl.invoke(HttpExecutorServiceImpl.java:56)
        ... 12 more
Caused by: org.apache.http.ProtocolException: Target host is not specified
        at org.apache.http.impl.conn.DefaultRoutePlanner.determineRoute(DefaultRoutePlanner.java:70)
        at org.apache.http.impl.client.InternalHttpClient.determineRoute(InternalHttpClient.java:124)
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:183)
        ... 17 more
```

I suspect this might be related to this ticket [1] so I'm hoping disabling it
will resolve the issue for now. When we're ready to enable this, we'll likely be
updating the plugin anyway which should hopefully resolve the issue properly.

[1] https://support.osuosl.org/Ticket/Display.html?id=30194