### PR TITLE
Create new GPU labels for CUDA 9.1 and 9.2

### DIFF
--- a/libraries/sge.rb
+++ b/libraries/sge.rb
@@ -1,15 +1,20 @@
 module OSLSGE
   module Helper
     # rubocop:disable Metrics/ParameterLists
-    def add_sge_cloud(name, queue, label, hostname, username, password, port)
+    def header_sge_cloud
       <<-EOH.gsub(/^ {8}/, '')
         import org.jenkinsci.plugins.sge.*
         import jenkins.model.*
         import hudson.model.*;
 
         def instance = Jenkins.getInstance()
+      EOH
+    end
 
-        BatchCloud sge = new BatchCloud(
+    def add_sge_cloud(name, queue, label, hostname, username, password, port)
+      <<-EOH.gsub(/^ {8}/, '')
+
+        BatchCloud sge_#{name.tr('-', '_')} = new BatchCloud(
           '#{name}',    // cloudName
           '#{queue}',   // queueType
           '#{label}',   // label
@@ -20,7 +25,7 @@ module OSLSGE
           '#{password}' // password
         )
 
-        instance.clouds.add(sge);
+        instance.clouds.add(sge_#{name.tr('-', '_')});
       EOH
     end
   end

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -178,11 +178,36 @@ docker_cloud =
   )
 
 # openstack_cloud = add_openstack_cloud
-sge_cloud =
+
+sge_cloud = header_sge_cloud
+# Default label for GPU jobs
+sge_cloud +=
   add_sge_cloud(
     'CGRB-ubuntu',
     'docker_gpu',
     'docker-gpu',
+    sge['hostname'],
+    sge['username'],
+    sge['password'],
+    sge['port']
+  )
+# Label for using CUDA 9.1
+sge_cloud +=
+  add_sge_cloud(
+    'CGRB-ubuntu-cuda91',
+    'docker_gpu@openpower3',
+    'docker-gpu-cuda91',
+    sge['hostname'],
+    sge['username'],
+    sge['password'],
+    sge['port']
+  )
+# Label for using CUDA 9.2
+sge_cloud +=
+  add_sge_cloud(
+    'CGRB-ubuntu-cuda92',
+    'docker_gpu@openpower2',
+    'docker-gpu-cuda92',
     sge['hostname'],
     sge['username'],
     sge['password'],

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -162,14 +162,48 @@ describe 'osl-jenkins::powerci' do
       # it do
       #   expect(chef_run).to execute_jenkins_script('Add OpenStack Cloud')
       # end
-      it do
+      it 'Add SGE Cloud: default' do
         expect(chef_run).to execute_jenkins_script('Add SGE Cloud')
           .with(
             command: %r{
-BatchCloud sge = new BatchCloud\(
+BatchCloud sge_CGRB_ubuntu = new BatchCloud\(
   'CGRB-ubuntu',    // cloudName
   'docker_gpu',   // queueType
   'docker-gpu',   // label
+  1440,         // maximumIdleMinutes
+  'sge.example.org', // hostname
+  22,      // port
+  'username', // username
+  'password' // password
+\)}
+
+          )
+      end
+      it 'Add SGE Cloud: cuda91' do
+        expect(chef_run).to execute_jenkins_script('Add SGE Cloud')
+          .with(
+            command: %r{
+BatchCloud sge_CGRB_ubuntu_cuda91 = new BatchCloud\(
+  'CGRB-ubuntu-cuda91',    // cloudName
+  'docker_gpu@openpower3',   // queueType
+  'docker-gpu-cuda91',   // label
+  1440,         // maximumIdleMinutes
+  'sge.example.org', // hostname
+  22,      // port
+  'username', // username
+  'password' // password
+\)}
+
+          )
+      end
+      it 'Add SGE Cloud: cuda92' do
+        expect(chef_run).to execute_jenkins_script('Add SGE Cloud')
+          .with(
+            command: %r{
+BatchCloud sge_CGRB_ubuntu_cuda92 = new BatchCloud\(
+  'CGRB-ubuntu-cuda92',    // cloudName
+  'docker_gpu@openpower2',   // queueType
+  'docker-gpu-cuda92',   // label
   1440,         // maximumIdleMinutes
   'sge.example.org', // hostname
   22,      // port

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -128,4 +128,32 @@ describe file('/var/lib/jenkins/config.xml') do
       <password>\{.*\}</password>
     <\/org.jenkinsci.plugins.sge.BatchCloud>})
   end
+  its(:content) do
+    should match(%r{
+    <org.jenkinsci.plugins.sge.BatchCloud plugin="sge-cloud-plugin@1.17">
+      <name>CGRB-ubuntu-cuda91</name>
+      <cloudName>CGRB-ubuntu-cuda91</cloudName>
+      <queueType>docker_gpu@openpower3</queueType>
+      <label>docker-gpu-cuda91</label>
+      <maximumIdleMinutes>1440</maximumIdleMinutes>
+      <hostname>sge.example.org</hostname>
+      <port>22</port>
+      <username>username</username>
+      <password>\{.*\}</password>
+    <\/org.jenkinsci.plugins.sge.BatchCloud>})
+  end
+  its(:content) do
+    should match(%r{
+    <org.jenkinsci.plugins.sge.BatchCloud plugin="sge-cloud-plugin@1.17">
+      <name>CGRB-ubuntu-cuda92</name>
+      <cloudName>CGRB-ubuntu-cuda92</cloudName>
+      <queueType>docker_gpu@openpower2</queueType>
+      <label>docker-gpu-cuda92</label>
+      <maximumIdleMinutes>1440</maximumIdleMinutes>
+      <hostname>sge.example.org</hostname>
+      <port>22</port>
+      <username>username</username>
+      <password>\{.*\}</password>
+    <\/org.jenkinsci.plugins.sge.BatchCloud>})
+  end
 end


### PR DESCRIPTION
We've run into an issue where one of our users is having problems running jobs
on two different machines in the same label [1]. This is due to the fact that
these two servers have different CUDA drivers installed. One that supports 9.2
and another that doesn't. To work around this issue we're going to create two
new labels which point to the specific hosts which should work.

I needed to refactor the code for SGE a bit to deal with adding more than one
SGE cloud, but other than that, it's the same logic as before.

[1] https://support.osuosl.org/Ticket/Display.html?id=30202