### PR TITLE
Set SSH connection timeout to 600 seconds

### DIFF
--- a/libraries/docker.rb
+++ b/libraries/docker.rb
@@ -98,6 +98,7 @@ module OSLDocker
             new DockerComputerSSHConnector(
               new DockerComputerSSHConnector.ManuallyConfiguredSSHKey('#{ssh_cred_id}', strategy)
             )
+          sshConnector.setLaunchTimeoutSeconds(600)
           ArrayList<DockerTemplate> dkTemplates = new ArrayList<DockerTemplate>();
           #{docker_images}
           ArrayList<DockerCloud> dkCloud = new ArrayList<DockerCloud>();

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,7 @@ shared_context 'common_stubs' do
     stub_command("chef gem list -i -v '< 2.0.0' netaddr").and_return(true)
     stub_command("chef gem list -i -v '>= 2.0.0' netaddr").and_return(false)
     stub_command('chef gem list -i kitchen-transport-rsync').and_return(false)
+    stub_command("chef gem list -i -v '= 2.7.5' rubygems")
   end
 end
 

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -112,6 +112,7 @@ describe file('/var/lib/jenkins/config.xml') do
     its(:content) { should match(%r{<image>#{image}</image>}) }
   end
   its(:content) { should match(/<string>JENKINS_SLAVE_SSH_PUBKEY=ssh-rsa AAAAB3.*/) }
+  its(:content) { should match(/<launchTimeoutSeconds>600.*/) }
   its(:content) { should match(%r{<credentialsId>powerci-docker</credentialsId>}) }
   its(:content) { should match(%r{<uri>tcp://127.0.0.1:2375</uri>}) }
   its(:content) do


### PR DESCRIPTION
This is to work around a leak issue we're running into on the powerci jenkins.
It seems to be related to this [1] and has a suggested workaround which is this.
We've already updated the ssh-agents plugin to the version higher than they
suggest.

[1] https://support.cloudbees.com/hc/en-us/articles/115002327291-SSH-Agents-leak-Computer-threadPoolForRemoting-threads