### PR TITLE
Remove docker-gpu-cuda91 label

### DIFF
--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -191,17 +191,6 @@ sge_cloud +=
     sge['password'],
     sge['port']
   )
-# Label for using CUDA 9.1
-sge_cloud +=
-  add_sge_cloud(
-    'CGRB-ubuntu-cuda91',
-    'docker_gpu@openpower3',
-    'docker-gpu-cuda91',
-    sge['hostname'],
-    sge['username'],
-    sge['password'],
-    sge['port']
-  )
 # Label for using CUDA 9.2
 sge_cloud +=
   add_sge_cloud(

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -201,23 +201,6 @@ BatchCloud sge_CGRB_ubuntu = new BatchCloud\(
 
           )
       end
-      it 'Add SGE Cloud: cuda91' do
-        expect(chef_run).to execute_jenkins_script('Add SGE Cloud')
-          .with(
-            command: %r{
-BatchCloud sge_CGRB_ubuntu_cuda91 = new BatchCloud\(
-  'CGRB-ubuntu-cuda91',    // cloudName
-  'docker_gpu@openpower3',   // queueType
-  'docker-gpu-cuda91',   // label
-  1440,         // maximumIdleMinutes
-  'sge.example.org', // hostname
-  22,      // port
-  'username', // username
-  'password' // password
-\)}
-
-          )
-      end
       it 'Add SGE Cloud: cuda92' do
         expect(chef_run).to execute_jenkins_script('Add SGE Cloud')
           .with(

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -141,20 +141,6 @@ describe file('/var/lib/jenkins/config.xml') do
   its(:content) do
     should match(%r{
     <org.jenkinsci.plugins.sge.BatchCloud plugin="sge-cloud-plugin@1.17">
-      <name>CGRB-ubuntu-cuda91</name>
-      <cloudName>CGRB-ubuntu-cuda91</cloudName>
-      <queueType>docker_gpu@openpower3</queueType>
-      <label>docker-gpu-cuda91</label>
-      <maximumIdleMinutes>1440</maximumIdleMinutes>
-      <hostname>sge.example.org</hostname>
-      <port>22</port>
-      <username>username</username>
-      <password>\{.*\}</password>
-    <\/org.jenkinsci.plugins.sge.BatchCloud>})
-  end
-  its(:content) do
-    should match(%r{
-    <org.jenkinsci.plugins.sge.BatchCloud plugin="sge-cloud-plugin@1.17">
       <name>CGRB-ubuntu-cuda92</name>
       <cloudName>CGRB-ubuntu-cuda92</cloudName>
       <queueType>docker_gpu@openpower2</queueType>


### PR DESCRIPTION
CGRB is going to be taking the machine this label uses out of rotation so that
we can use it as an OpenStack GPU node. There are no current jobs using this
label so it should be safe to remove.