### PR TITLE
Add CUDA 10.0 images

### DIFF
--- a/attributes/ibmz_ci.rb
+++ b/attributes/ibmz_ci.rb
@@ -2,7 +2,10 @@ default['osl-jenkins']['ibmz_ci']['docker_images'] = %w(
   osuosl/ubuntu-s390x:16.04
   osuosl/ubuntu-s390x:18.04
   osuosl/debian-s390x:9
+  osuosl/debian-s390x:buster
+  osuosl/debian-s390x:unstable
   osuosl/fedora-s390x:28
+  osuosl/fedora-s390x:29
 )
 default['osl-jenkins']['ibmz_ci']['docker']['memory_limit'] = 'null'
 default['osl-jenkins']['ibmz_ci']['docker']['memory_swap'] = 'null'

--- a/attributes/powerci.rb
+++ b/attributes/powerci.rb
@@ -2,18 +2,25 @@ default['osl-jenkins']['powerci']['docker_images'] = %w(
   osuosl/ubuntu-ppc64le:16.04
   osuosl/ubuntu-ppc64le:18.04
   osuosl/ubuntu-ppc64le-cuda:8.0
+  osuosl/ubuntu-ppc64le-cuda:9.0
+  osuosl/ubuntu-ppc64le-cuda:9.1
+  osuosl/ubuntu-ppc64le-cuda:9.2
+  osuosl/ubuntu-ppc64le-cuda:10.0
   osuosl/ubuntu-ppc64le-cuda:8.0-cudnn6
   osuosl/ubuntu-ppc64le-cuda:9.0-cudnn7
   osuosl/ubuntu-ppc64le-cuda:9.1-cudnn7
   osuosl/ubuntu-ppc64le-cuda:9.2-cudnn7
+  osuosl/ubuntu-ppc64le-cuda:10.0-cudnn7
   osuosl/debian-ppc64le:9
   osuosl/debian-ppc64le:buster
   osuosl/debian-ppc64le:unstable
-  osuosl/fedora-ppc64le:26
-  osuosl/fedora-ppc64le:27
   osuosl/fedora-ppc64le:28
+  osuosl/fedora-ppc64le:29
   osuosl/centos-ppc64le:7
   osuosl/centos-ppc64le-cuda:8.0
+  osuosl/centos-ppc64le-cuda:9.0
+  osuosl/centos-ppc64le-cuda:9.1
+  osuosl/centos-ppc64le-cuda:9.2
   osuosl/centos-ppc64le-cuda:8.0-cudnn6
   osuosl/centos-ppc64le-cuda:9.0-cudnn7
   osuosl/centos-ppc64le-cuda:9.1-cudnn7

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -106,7 +106,10 @@ describe 'osl-jenkins::ibmz_ci' do
           osuosl/ubuntu-s390x:16.04
           osuosl/ubuntu-s390x:18.04
           osuosl/debian-s390x:9
+          osuosl/debian-s390x:buster
+          osuosl/debian-s390x:unstable
           osuosl/fedora-s390x:28
+          osuosl/fedora-s390x:29
         ).each do |image|
           expect(chef_run).to execute_jenkins_script('Add Docker Cloud').with(command: %r{'#{image}', // image})
           expect(chef_run).to execute_jenkins_script('Add Docker Cloud')

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -130,18 +130,25 @@ describe 'osl-jenkins::powerci' do
           osuosl/ubuntu-ppc64le:16.04
           osuosl/ubuntu-ppc64le:18.04
           osuosl/ubuntu-ppc64le-cuda:8.0
+          osuosl/ubuntu-ppc64le-cuda:9.0
+          osuosl/ubuntu-ppc64le-cuda:9.1
+          osuosl/ubuntu-ppc64le-cuda:9.2
+          osuosl/ubuntu-ppc64le-cuda:10.0
           osuosl/ubuntu-ppc64le-cuda:8.0-cudnn6
           osuosl/ubuntu-ppc64le-cuda:9.0-cudnn7
           osuosl/ubuntu-ppc64le-cuda:9.1-cudnn7
           osuosl/ubuntu-ppc64le-cuda:9.2-cudnn7
+          osuosl/ubuntu-ppc64le-cuda:10.0-cudnn7
           osuosl/debian-ppc64le:9
           osuosl/debian-ppc64le:buster
           osuosl/debian-ppc64le:unstable
-          osuosl/fedora-ppc64le:26
-          osuosl/fedora-ppc64le:27
           osuosl/fedora-ppc64le:28
+          osuosl/fedora-ppc64le:29
           osuosl/centos-ppc64le:7
           osuosl/centos-ppc64le-cuda:8.0
+          osuosl/centos-ppc64le-cuda:9.0
+          osuosl/centos-ppc64le-cuda:9.1
+          osuosl/centos-ppc64le-cuda:9.2
           osuosl/centos-ppc64le-cuda:8.0-cudnn6
           osuosl/centos-ppc64le-cuda:9.0-cudnn7
           osuosl/centos-ppc64le-cuda:9.1-cudnn7

--- a/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
+++ b/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
@@ -98,7 +98,10 @@ describe file('/var/lib/jenkins/config.xml') do
     osuosl/ubuntu-s390x:16.04
     osuosl/ubuntu-s390x:18.04
     osuosl/debian-s390x:9
+    osuosl/debian-s390x:buster
+    osuosl/debian-s390x:unstable
     osuosl/fedora-s390x:28
+    osuosl/fedora-s390x:29
   ).each do |image|
     its(:content) { should match(%r{<image>#{image}</image>}) }
     its(:content) { should match(%r{<labelString>docker-#{image.tr('/:', '-')}</labelString>}) }

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -101,18 +101,25 @@ describe file('/var/lib/jenkins/config.xml') do
     osuosl/ubuntu-ppc64le:16.04
     osuosl/ubuntu-ppc64le:18.04
     osuosl/ubuntu-ppc64le-cuda:8.0
+    osuosl/ubuntu-ppc64le-cuda:9.0
+    osuosl/ubuntu-ppc64le-cuda:9.1
+    osuosl/ubuntu-ppc64le-cuda:9.2
+    osuosl/ubuntu-ppc64le-cuda:10.0
     osuosl/ubuntu-ppc64le-cuda:8.0-cudnn6
     osuosl/ubuntu-ppc64le-cuda:9.0-cudnn7
     osuosl/ubuntu-ppc64le-cuda:9.1-cudnn7
     osuosl/ubuntu-ppc64le-cuda:9.2-cudnn7
+    osuosl/ubuntu-ppc64le-cuda:10.0-cudnn7
     osuosl/debian-ppc64le:9
     osuosl/debian-ppc64le:buster
     osuosl/debian-ppc64le:unstable
-    osuosl/fedora-ppc64le:26
-    osuosl/fedora-ppc64le:27
     osuosl/fedora-ppc64le:28
+    osuosl/fedora-ppc64le:29
     osuosl/centos-ppc64le:7
     osuosl/centos-ppc64le-cuda:8.0
+    osuosl/centos-ppc64le-cuda:9.0
+    osuosl/centos-ppc64le-cuda:9.1
+    osuosl/centos-ppc64le-cuda:9.2
     osuosl/centos-ppc64le-cuda:8.0-cudnn6
     osuosl/centos-ppc64le-cuda:9.0-cudnn7
     osuosl/centos-ppc64le-cuda:9.1-cudnn7


### PR DESCRIPTION
In addition:

- Include the buster and unstable tags for the Debian s390x image
- Update to Fedora 29 and remove anything older than 28
- Include all of the base CUDA images between 9.0-9.2 which seemed to have been
  accidentally left off

This also resolves RT 30455 [1]

[1] https://support.osuosl.org/Ticket/Display.html?id=30455