### PR TITLE
Remove gwm and phase_out_nginx environments

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -82,11 +82,9 @@ suites:
             - 'osuosl-cookbooks/staff'
           chef_repo: 'osuosl/chef-repo'
           default_environments:
-            - openstack_mitaka
-            - phase_out_nginx
+            - openstack_ocata
             - phpbb
             - production
-            - testing
             - workstation
           org: 'osuosl-cookbooks'
           override_repos:

--- a/recipes/jenkins1.rb
+++ b/recipes/jenkins1.rb
@@ -20,9 +20,7 @@ node.default['osl-jenkins']['cookbook_uploader'].tap do |conf|
   conf['authorized_teams'] = %w(osuosl-cookbooks/staff)
   conf['chef_repo'] = 'osuosl/chef-repo'
   conf['default_environments'] = %w(
-    gwm
     openstack_ocata
-    phase_out_nginx
     phpbb
     production
     workstation


### PR DESCRIPTION
These are no longer being used and are being removed in osuosl/chef-repo#1867.