### PR TITLE
Add docker-custom-build-environment plugin on powerci and ibmz-ci instances

### DIFF
--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -50,6 +50,7 @@ node.default['osl-jenkins']['plugins'].tap do |p|
   p['cloud-stats'] = '0.11'
   p['config-file-provider'] = '3.6'
   p['docker-build-publish'] = '1.3.2'
+  p['docker-custom-build-environment'] = '1.7.3'
   p['docker-java-api'] = '3.0.14'
   p['docker-plugin'] = '1.1.3'
   p['docker-workflow'] = '1.15.1'

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -50,6 +50,7 @@ node.default['osl-jenkins']['plugins'].tap do |p|
   p['cloud-stats'] = '0.14'
   p['config-file-provider'] = '3.6'
   p['docker-build-publish'] = '1.3.2'
+  p['docker-custom-build-environment'] = '1.7.3'
   p['docker-java-api'] = '3.0.14'
   p['docker-plugin'] = '1.1.3'
   p['docker-workflow'] = '1.15.1'

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -58,6 +58,7 @@ describe 'osl-jenkins::ibmz_ci' do
         display-url-api:2.2.0
         docker-build-publish:1.3.2
         docker-commons:1.11
+        docker-custom-build-environment:1.7.3
         docker-java-api:3.0.14
         docker-plugin:1.1.3
         durable-task:1.17

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -61,6 +61,7 @@ describe 'osl-jenkins::powerci' do
         display-url-api:2.2.0
         docker-build-publish:1.3.2
         docker-commons:1.11
+        docker-custom-build-environment:1.7.3
         docker-java-api:3.0.14
         docker-plugin:1.1.3
         durable-task:1.17

--- a/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
+++ b/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
@@ -30,6 +30,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     display-url-api:2.2.0
     docker-build-publish:1.3.2
     docker-commons:1.11
+    docker-custom-build-environment:1.7.3
     docker-java-api:3.0.14
     docker-plugin:1.1.3
     docker-workflow:1.15.1

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -31,6 +31,7 @@ describe command('java -jar /tmp/kitchen/cache/jenkins-cli.jar -s http://localho
     display-url-api:2.2.0
     docker-build-publish:1.3.2
     docker-commons:1.11
+    docker-custom-build-environment:1.7.3
     docker-java-api:3.0.14
     docker-plugin:1.1.3
     docker-workflow:1.15.1


### PR DESCRIPTION
This will allow projects to deploy their jobs using docker using any container
image they need or want.