### PR TITLE
Set alfred gid/uid to something static

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,24 +22,27 @@ node.default['java']['jdk_version'] = '8'
 
 include_recipe 'java'
 
+ohai 'jenkins_reload_passwd' do
+  action :nothing
+  plugin 'etc'
+end
+
 group 'alfred' do
+  gid 10000
   action :create
+  notifies :reload, 'ohai[jenkins_reload_passwd]', :immediately
 end
 
 user 'alfred' do
   manage_home true
-  gid 'alfred'
+  uid 10000
+  gid 10000
   system true
   shell '/bin/bash'
   home '/home/alfred'
   action :create
+  notifies :reload, 'ohai[jenkins_reload_passwd]', :immediately
 end
-
-# This is necessary due to a bug in the upstream "ssh_keys" cookbook
-ohai 'jenkins_reload_passwd' do
-  action :nothing
-  plugin 'etc'
-end.run_action(:reload)
 
 node.default['ssh_keys']['alfred'] = 'alfred'
 include_recipe 'ssh-keys'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -12,21 +12,26 @@ describe 'osl-jenkins::default' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to create_group('alfred')
+        expect(chef_run).to create_group('alfred').with(gid: 10000)
       end
       it do
         expect(chef_run).to create_user('alfred').with(
           manage_home: true,
-          gid: 'alfred',
+          uid: 10000,
+          gid: 10000,
           system: true,
           shell: '/bin/bash',
           home: '/home/alfred'
         )
       end
       it do
-        expect(chef_run).to reload_ohai('jenkins_reload_passwd').with(
-          plugin: 'etc'
-        )
+        expect(chef_run.group('alfred')).to notify('ohai[jenkins_reload_passwd]').to(:reload).immediately
+      end
+      it do
+        expect(chef_run.user('alfred')).to notify('ohai[jenkins_reload_passwd]').to(:reload).immediately
+      end
+      it do
+        expect(chef_run.ohai('jenkins_reload_passwd')).to do_nothing
       end
     end
   end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -8,6 +8,7 @@ end
 
 describe group('alfred') do
   it { should exist }
+  it { should have_gid 10000 }
 end
 
 describe user('alfred') do
@@ -15,6 +16,7 @@ describe user('alfred') do
   it { should belong_to_group 'alfred' }
   it { should have_login_shell '/bin/bash' }
   it { should have_home_directory '/home/alfred' }
+  it { should have_uid 10000 }
 end
 
 describe file('/home/alfred/.ssh/authorized_keys') do


### PR DESCRIPTION
This is needed for utilizing the docker-custom-build-environment plugin. We need
to have a known static UID in containers on all hosts acting as a jenkins node.
I will be deploying a one-time manual fix on each current node as this doesn't
fix any current running processes or change the gid for the home directory
correctly from the current setup.