### PR TITLE
Remove reliance on chef-sugar since we don't need it here anyway

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -116,7 +116,7 @@ cookbook_file git_config_path do
   group node['jenkins']['master']['group']
 end
 
-node.deep_fetch('osl-jenkins', 'gems').each do |g|
+node['osl-jenkins']['gems'].each do |g|
   chef_gem g do # ~FC009
     compile_time true
   end


### PR DESCRIPTION
We never added it in the metadata.rb so this is the only change that's needed.