### PR TITLE
Ensure we only install < 2.0 for openstack_taster

### DIFF
--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -110,6 +110,7 @@ end
 # install openstack_taster
 chef_gem 'openstack_taster' do
   compile_time true
+  version '< 2.0'
   options '--no-user-install'
   clear_sources true
   action :upgrade

--- a/spec/unit/recipes/packer_pipeline_node_spec.rb
+++ b/spec/unit/recipes/packer_pipeline_node_spec.rb
@@ -73,6 +73,7 @@ describe 'osl-jenkins::packer_pipeline_node' do
       it do
         expect(chef_run).to upgrade_chef_gem('openstack_taster').with(
           options: '--no-user-install',
+          version: '< 2.0',
           clear_sources: true
         )
       end

--- a/test/integration/packer_pipeline_node/inspec/packer_pipeline_node_spec.rb
+++ b/test/integration/packer_pipeline_node/inspec/packer_pipeline_node_spec.rb
@@ -48,6 +48,11 @@ describe file('/opt/chef/embedded/bin/openstack_taster') do
   it { should be_executable }
 end
 
+describe gem('openstack_taster', '/opt/chef/embedded/bin/gem') do
+  it { should be_installed }
+  its('version') { should < '2.0' }
+end
+
 describe command('berks version') do
   its('exit_status') { should eq 0 }
 end


### PR DESCRIPTION
For preparing for Chef 14, we need to update the version of InSpec we depend on.
We'll be making that change in 2.0 of openstack_taster so let's ensure the
current environment doesn't accidentally pull in the newer version once it's
pushed.

NOTE: The automatic tests will likely fail since this cookbook hasn't been updated to 14 yet, however this is a pre-req for it.