### PR TITLE
Use vhost hostname for jenkins server webhooks

### DIFF
--- a/attributes/cookbook_uploader.rb
+++ b/attributes/cookbook_uploader.rb
@@ -2,6 +2,9 @@
 ### Attributes that you probably want to override:
 ###
 
+# String; jenkins server vhost
+default['osl-jenkins']['cookbook_uploader']['jenkins_server'] = 'jenkins.osuosl.org'
+
 # String; name of GitHub organization that contains your cookbooks.
 default['osl-jenkins']['cookbook_uploader']['org'] = ''
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,5 +1,5 @@
 def public_address
-  node.fetch('fqdn', {}) || node['ipaddress']
+  node['osl-jenkins']['cookbook_uploader']['jenkins_server']
 end
 
 def credential_secrets


### PR DESCRIPTION
By default, we're using the FQDN for setting the hostname used in Github
webhooks. This becomes a problem when deploying more than one OSL Jenkins server
for a migration. It makes more sense to just point to the hostname we actually
use for our Jenkins instance.

This should make it easier to do major server platform upgrades on our primary
Jenkins server.