### PR TITLE
Pin java cookbook to < 8.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ source_url       'https://github.com/osuosl-cookbooks/osl-jenkins'
 
 depends          'base', '>= 2.6.0'
 depends          'git'
-depends          'java'
+depends          'java', '< 8.0'
 depends          'jenkins', '~> 7.1.0'
 depends          'osl-haproxy'
 depends          'osl-docker'


### PR DESCRIPTION
Some breaking changes in 8.0 that require Chef 15.