### PR TITLE
Temporarily disable installation of the openstack_taster gem

### DIFF
--- a/recipes/bumpzone.rb
+++ b/recipes/bumpzone.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: bumpzone
 #
-# Copyright:: 2017-2020, Oregon State University
+# Copyright:: 2017-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/chef_backup.rb
+++ b/recipes/chef_backup.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: chef_backup
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/chef_ci_cookbook_template.rb
+++ b/recipes/chef_ci_cookbook_template.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: chef_ci_cookbook_template
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: cookbook_uploader
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: default
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ftp.rb
+++ b/recipes/ftp.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: ftp
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/github_comment.rb
+++ b/recipes/github_comment.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: github_comment
 #
-# Copyright:: 2017-2020, Oregon State University
+# Copyright:: 2017-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/haproxy.rb
+++ b/recipes/haproxy.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: haproxy
 #
-# Copyright:: 2014-2020, Oregon State University
+# Copyright:: 2014-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: ibmz_ci
 #
-# Copyright:: 2018-2020, Oregon State University
+# Copyright:: 2018-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/jenkins1.rb
+++ b/recipes/jenkins1.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: jenkins1
 #
-# Copyright:: 2017-2020, Oregon State University
+# Copyright:: 2017-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: master
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/packer_pipeline_master.rb
+++ b/recipes/packer_pipeline_master.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: packer_pipeline
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/packer_pipeline_node.rb
+++ b/recipes/packer_pipeline_node.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: packer_pipeline
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -109,10 +109,11 @@ file '/home/alfred/openstack_credentials.json' do
 end
 
 # install openstack_taster
-chef_gem 'openstack_taster' do
-  compile_time true
-  version Chef::VERSION.to_i < 14 ? '< 2.0' : '>= 2.0'
-  options '--no-user-install'
-  clear_sources true
-  action :upgrade
-end
+# TODO: Remove this once we're completely done using this
+# chef_gem 'openstack_taster' do
+#   compile_time true
+#   version Chef::VERSION.to_i < 14 ? '< 2.0' : '>= 2.0'
+#   options '--no-user-install'
+#   clear_sources true
+#   action :upgrade
+# end

--- a/recipes/plugins.rb
+++ b/recipes/plugins.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: plugins
 #
-# Copyright:: 2015-2020, Oregon State University
+# Copyright:: 2015-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: powerci
 #
-# Copyright:: 2017-2020, Oregon State University
+# Copyright:: 2017-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/site_pr_builder.rb
+++ b/recipes/site_pr_builder.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-jenkins
 # Recipe:: github_comment
 #
-# Copyright:: 2017-2020, Oregon State University
+# Copyright:: 2017-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/packer_pipeline_node_spec.rb
+++ b/spec/unit/recipes/packer_pipeline_node_spec.rb
@@ -79,13 +79,13 @@ describe 'osl-jenkins::packer_pipeline_node' do
         )
       end
 
-      it do
-        expect(chef_run).to upgrade_chef_gem('openstack_taster').with(
-          options: '--no-user-install',
-          version: '>= 2.0',
-          clear_sources: true
-        )
-      end
+      # it do
+      #   expect(chef_run).to upgrade_chef_gem('openstack_taster').with(
+      #     options: '--no-user-install',
+      #     version: '>= 2.0',
+      #     clear_sources: true
+      #   )
+      # end
     end
   end
 end

--- a/test/integration/packer_pipeline_node/inspec/packer_pipeline_node_spec.rb
+++ b/test/integration/packer_pipeline_node/inspec/packer_pipeline_node_spec.rb
@@ -51,10 +51,10 @@ describe file("/opt/#{chef}/embedded/bin/openstack_taster") do
   it { should be_executable }
 end
 
-describe gem('openstack_taster', "/opt/#{chef}/embedded/bin/gem") do
-  it { should be_installed }
-  its('version') { should >= '2.0' }
-end
+# describe gem('openstack_taster', "/opt/#{chef}/embedded/bin/gem") do
+#   it { should be_installed }
+#   its('version') { should >= '2.0' }
+# end
 
 describe command('berks version') do
   its('exit_status') { should eq 0 }


### PR DESCRIPTION
We are not currently using it and I'm not planning on using it in the future however I'm not ready to completely remove the code here just in case.

This should fix chef runs that are currently failing due to this.

In addition, cookstyle fixes.
