### PR TITLE
Bump yum-versionlock cookbook version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ depends          'osl-haproxy'
 depends          'osl-docker'
 depends          'certificate'
 depends          'users'
-depends          'yum-plugin-versionlock'
+depends          'yum-plugin-versionlock', '>= 0.4.0'
 depends          'yum-qemu-ev'
 
 supports         'centos', '~> 7.0'


### PR DESCRIPTION
No other changes needed to use the latest version.