### PR TITLE
Put a ceiling on users cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ depends          'jenkins', '~> 8.0.2'
 depends          'osl-haproxy'
 depends          'osl-docker'
 depends          'certificate'
-depends          'users'
+depends          'users', '< 6.0.0'
 depends          'yum-plugin-versionlock', '>= 0.4.0'
 depends          'yum-qemu-ev'
 


### PR DESCRIPTION
6.x and above removes support for data bags natively and we're not ready for that yet.
