### PR TITLE
Move linting command to script

### DIFF
--- a/templates/default/site_pr_builder_config.xml.erb
+++ b/templates/default/site_pr_builder_config.xml.erb
@@ -88,8 +88,8 @@
       <command>
 export PELICAN_SITE_URL="<%= @site_url %>"
 export RSYNC_TARGET_DIR="<%= @rsync_target %>"
-exec scripts/build.sh
-make lint_changed
+export CHECK_LINT="1"
+bash scripts/build.sh
       </command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
This ensures that it uses the virtual environment so that it can use the doc8 binary.

Signed-off-by: Lance Albertson <lance@osuosl.org>
