### PR TITLE
Bump to java-11.2.2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ source_url       'https://github.com/osuosl-cookbooks/osl-jenkins'
 
 depends          'base', '>= 2.6.0'
 depends          'osl-git'
-depends          'java', '>= 8.1.0'
+depends          'java', '~> 11.2.2'
 depends          'jenkins', '~> 9.5.1'
 depends          'osl-haproxy'
 depends          'osl-docker'


### PR DESCRIPTION
Also avoid java-12 cookbook until they fix the issues.

Signed-off-by: Lance Albertson <lance@osuosl.org>
