### PR TITLE
Set TimeoutStartSec to just under 10 minutes

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -142,6 +142,7 @@ action :create do
       Environment="CASC_JENKINS_CONFIG=/var/lib/jenkins/casc_configs"
       Environment="JAVA_OPTS=-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false"
       LimitNOFILE=8192
+      TimeoutStartSec=590
     EOF
   end
 end

--- a/spec/unit/recipes/controller_spec.rb
+++ b/spec/unit/recipes/controller_spec.rb
@@ -154,6 +154,7 @@ describe 'jenkins_test::controller' do
             Environment="CASC_JENKINS_CONFIG=/var/lib/jenkins/casc_configs"
             Environment="JAVA_OPTS=-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false"
             LimitNOFILE=8192
+            TimeoutStartSec=590
           EOF
         )
       end


### PR DESCRIPTION
This will allow Jenkins to start fully and not exceed Chef's 10 minute timeout.

Signed-off-by: Lance Albertson <lance@osuosl.org>