### PR TITLE
Delete JASC configs for archived repositories

### DIFF
--- a/attributes/cookbook_uploader.rb
+++ b/attributes/cookbook_uploader.rb
@@ -56,6 +56,13 @@ default['osl-jenkins']['cookbook_uploader']['all_environments_word'] = '*'
 # GitHub organization.
 default['osl-jenkins']['cookbook_uploader']['override_repos'] = nil
 
+# Array<String>; If "nil", Jenkins automation will be remove up for all repos in
+# the above cookbook organization. If an array of repo names (not prefixed) is
+# given, only they will have the automation set up. This is useful if you wish
+# to test automation only on one or two repos before deploying to the entire
+# GitHub organization.
+default['osl-jenkins']['cookbook_uploader']['override_archived_repos'] = nil
+
 # Boolean; Whether to allow GitHub pushes to insecure URLs; useful for testing
 # on a local Jenkins instance that doesn't have a valid SSL cert.
 default['osl-jenkins']['cookbook_uploader']['github_insecure_hook'] = false

--- a/libraries/github.rb
+++ b/libraries/github.rb
@@ -10,8 +10,8 @@ if defined?(Faraday::HttpCache)
   Octokit.middleware = stack
 end
 
-# Given a GitHub organization name and a GitHub API token with access to view
-# the repositories in that org, returns a list of all repo names in the org.
+# Given a GitHub organization name and a GitHub API token with access to view the repositories in that org, returns a
+# list of all repo names in the org that are not archived.
 #
 # @param github_token [String] GitHub API token with permissions to view
 #   repositories on the given repo.
@@ -21,7 +21,20 @@ def collect_github_repositories(github_token, org_name)
   github = Octokit::Client.new(access_token: github_token)
   github.auto_paginate = true
 
-  github.org_repos(org_name).map(&:name)
+  github.org_repos(org_name).reject(&:archived?).map(&:name)
+end
+
+# Given a GitHub organization name and a GitHub API token with access to view the repositories in that org, returns a
+# list of all repo names in the org that are archived.
+#
+# @param github_token [String] GitHub API token with permissions to view repositories on the given repo.
+# @param org_name [String] Name of GitHub organization.
+def collect_archived_github_repositories(github_token, org_name)
+  require 'octokit'
+  github = Octokit::Client.new(access_token: github_token)
+  github.auto_paginate = true
+
+  github.org_repos(org_name).select(&:archived?).map(&:name)
 end
 
 # Sets up a GitHub trigger for the Jenkins cookbook uploader job.  It will

--- a/spec/unit/recipes/cookbook_uploader_spec.rb
+++ b/spec/unit/recipes/cookbook_uploader_spec.rb
@@ -11,6 +11,7 @@ describe 'osl-jenkins::cookbook_uploader' do
             'authorized_teams' => %w(osuosl-cookbooks/staff),
             'default_environments' => %w(production workstation),
             'override_repos' => %w(test-cookbook),
+            'override_archived_repos' => %w(archived-cookbook),
             'github_insecure_hook' => true,
             'do_not_upload_cookbooks' => true,
           }
@@ -97,6 +98,11 @@ describe 'osl-jenkins::cookbook_uploader' do
       end
       it do
         expect(chef_run.osl_jenkins_job('cookbook-uploader-osuosl-cookbooks-test-cookbook')).to \
+          notify('osl_jenkins_service[cookbook_uploader]').to(:restart).delayed
+      end
+      it { is_expected.to delete_osl_jenkins_job 'cookbook-uploader-osuosl-cookbooks-archived-cookbook' }
+      it do
+        expect(chef_run.osl_jenkins_job('cookbook-uploader-osuosl-cookbooks-archived-cookbook')).to \
           notify('osl_jenkins_service[cookbook_uploader]').to(:restart).delayed
       end
     end

--- a/spec/unit/recipes/jenkins1_spec.rb
+++ b/spec/unit/recipes/jenkins1_spec.rb
@@ -11,6 +11,7 @@ describe 'osl-jenkins::jenkins1' do
             'authorized_teams' => %w(osuosl-cookbooks/staff),
             'default_environments' => %w(production workstation),
             'override_repos' => %w(test-cookbook),
+            'override_archived_repos' => %w(archived-cookbook),
             'github_insecure_hook' => true,
             'do_not_upload_cookbooks' => true,
           }

--- a/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
+++ b/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
@@ -4,6 +4,11 @@ control 'cookbook-uploader' do
     its('headers.X-Jenkins') { should_not eq nil }
   end
 
+  describe http('https://127.0.0.1/job/cookbook-uploader-osuosl-cookbooks-archived-cookbook/', ssl_verify: false) do
+    its('status') { should eq 404 }
+    its('headers.X-Jenkins') { should_not eq nil }
+  end
+
   describe http('https://127.0.0.1/job/environment-bumper-osuosl-chef-repo/', ssl_verify: false) do
     its('status') { should eq 200 }
     its('headers.X-Jenkins') { should_not eq nil }


### PR DESCRIPTION
This also adds a check to only create jobs if the repo is not archived.

Signed-off-by: Lance Albertson <lance@osuosl.org>
