### PR TITLE
Rename diskSpaceMonitor to diskSpace

### DIFF
--- a/templates/default.yml.erb
+++ b/templates/default.yml.erb
@@ -9,7 +9,7 @@ jenkins:
   markupFormatter: "plainText"
   myViewsTabBar: "standard"
   nodeMonitors:
-  - diskSpaceMonitor:
+  - diskSpace:
       freeSpaceThreshold: "1GB"
   - tmpSpace:
       freeSpaceThreshold: "1GB"


### PR DESCRIPTION
This fixes the following issue:

  Configuration as Code obsolete file format:
   'diskSpaceMonitor' is obsolete, please use 'diskSpace'

https://support.osuosl.org/Ticket/Display.html?id=33413

Signed-off-by: Lance Albertson <lance@osuosl.org>
