### PR TITLE
Add basic-branch-build-strategies plugin on powerci/ibmz-ci

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,7 +3,7 @@ driver:
   name: dokken
   privileged: true  # because Docker and SystemD/Upstart
   chef_image: cincproject/cinc
-  chef_version: <%= ENV['CHEF_VERSION'] || '17' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || '18' %>
   pull_chef_image: false
   pull_platform_image: false
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,7 +16,7 @@ transport:
 provisioner:
   name: chef_infra
   product_name: cinc
-  product_version: '17'
+  product_version: '18'
   encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
   data_bags_path: test/integration/data_bags
   enforce_idempotency: true

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -29,6 +29,7 @@ osl_jenkins_install 'ibmz-ci.osuosl.org' do
   num_executors 0
   plugins %w(
     ansicolor
+    basic-branch-build-strategies
     build-monitor-plugin
     build-timeout
     cloud-stats

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -30,6 +30,7 @@ osl_jenkins_install 'powerci.osuosl.org' do
   num_executors 0
   plugins %w(
     ansicolor
+    basic-branch-build-strategies
     build-monitor-plugin
     build-timeout
     cloud-stats

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -56,6 +56,7 @@ describe 'osl-jenkins::ibmz_ci' do
           num_executors: 0,
           plugins: %w(
             ansicolor
+            basic-branch-build-strategies
             build-monitor-plugin
             build-timeout
             cloud-stats

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -51,6 +51,7 @@ describe 'osl-jenkins::powerci' do
           num_executors: 0,
           plugins: %w(
             ansicolor
+            basic-branch-build-strategies
             build-monitor-plugin
             build-timeout
             cloud-stats

--- a/templates/default.yml.erb
+++ b/templates/default.yml.erb
@@ -83,8 +83,6 @@ unclassified:
     charset: "UTF-8"
     useSsl: false
     useTls: false
-  mavenModuleSet:
-    localRepository: "default"
   pollSCM:
     pollingThreadCount: 10
   scmGit:

--- a/test/integration/ibmz_ci/controls/ibmz_ci_spec.rb
+++ b/test/integration/ibmz_ci/controls/ibmz_ci_spec.rb
@@ -6,6 +6,7 @@ control 'ibmz-ci' do
   describe command '/usr/local/bin/jenkins-plugin-cli -l' do
     %w(
       ansicolor
+      basic-branch-build-strategies
       build-monitor-plugin
       build-timeout
       cloud-stats

--- a/test/integration/powerci/controls/powerci_spec.rb
+++ b/test/integration/powerci/controls/powerci_spec.rb
@@ -6,6 +6,7 @@ control 'powerci' do
   describe command('/usr/local/bin/jenkins-plugin-cli -l') do
     %w(
       ansicolor
+      basic-branch-build-strategies
       build-monitor-plugin
       build-timeout
       cloud-stats


### PR DESCRIPTION
This was requested on this ticket [1].

In addition:

- Update default Chef version to 18
- Remove mavenModuleSet from default template as it breaks on new installs

[1] https://support.osuosl.org/Ticket/Display.html?id=33647#txn-738496

Signed-off-by: Lance Albertson <lance@osuosl.org>
