### PR TITLE
Add supermarket share to cookbook-uploader script

### DIFF
--- a/templates/default/github_pr_comment_trigger.rb.erb
+++ b/templates/default/github_pr_comment_trigger.rb.erb
@@ -162,10 +162,11 @@ git.add_tag("v#{version}")
 # Push back to Github
 git.push(git.remote('origin'), base_branch, tags: true)
 
-# Upload to the Chef server, freezing, ignoring dependencies
+# Upload to the Chef server and supermarket, freezing, ignoring dependencies
 $stderr.puts "Uploading #{repo_name} cookbook to the Chef server..."
 unless <%= @do_not_upload_cookbooks %>
   `knife cookbook upload #{repo_name} --freeze -o ../`
+  `knife supermarket share #{repo_name} -m https://supermarket.osuosl.org -o ../`
 end
 
 # Close the PR

--- a/templates/default/github_pr_comment_trigger.rb.erb
+++ b/templates/default/github_pr_comment_trigger.rb.erb
@@ -166,7 +166,7 @@ git.push(git.remote('origin'), base_branch, tags: true)
 $stderr.puts "Uploading #{repo_name} cookbook to the Chef server..."
 unless <%= @do_not_upload_cookbooks %>
   `knife cookbook upload #{repo_name} --freeze -o ../`
-  `knife supermarket share #{repo_name} -m https://supermarket.osuosl.org -o ../`
+  `knife supermarket share #{repo_name} Other -m https://supermarket.osuosl.org -o ../`
 end
 
 # Close the PR


### PR DESCRIPTION
Wasn't able to successfully test the `cookbook-uploaded` suite, as it failed to list the webhooks for `osuosl-cookbooks/test-cookbook`. I did test the new commands, personally, with success.

Will need help with looking into logging the Jenkins account into the supermarket before we push this to prod.