### PR TITLE
Remove excludeClientIPFromCrumb from CasC config

### DIFF
--- a/templates/default.yml.erb
+++ b/templates/default.yml.erb
@@ -1,7 +1,6 @@
 jenkins:
   crumbIssuer:
-    standard:
-      excludeClientIPFromCrumb: false
+    standard: {}
   disableRememberMe: false
   markupFormatter: "plainText"
   nodeMonitors:


### PR DESCRIPTION
- Option removed in Jenkins 2.543
- Client IP exclusion is now the default and only behavior
- Fixes ConfigurationAsCodeBootFailure on startup

Signed-off-by: Lance Albertson <lance@osuosl.org>
