### PR TITLE
Guard eager Octokit middleware setup on Octokit being loaded

### DIFF
--- a/libraries/github.rb
+++ b/libraries/github.rb
@@ -18,7 +18,10 @@ def patch_yajl_workaround
   @_yajl_patched = true
 end
 
-if defined?(Faraday::HttpCache)
+# Configure Octokit's middleware stack at load time so all clients pick up HTTP caching. Both gems must already be
+# loaded — guard on both constants since chefspec/berkshelf can load Faraday::HttpCache transitively without loading
+# Octokit, in which case this block previously raised NameError and aborted loading of the rest of the library.
+if defined?(Faraday::HttpCache) && defined?(Octokit)
   require 'faraday-http-cache'
 
   # Github API caching

--- a/libraries/github.rb
+++ b/libraries/github.rb
@@ -9,7 +9,7 @@ def patch_yajl_workaround
   Sawyer::Serializer.define_singleton_method(:yajl) do
     require 'yajl'
     new(Yajl)
-  rescue LoadError, NameError
+  rescue LoadError, NameError # rubocop:disable Lint/SuppressedException -- intentional: fall through so MultiJson selects a different adapter
   end
 
   require 'multi_json'

--- a/libraries/github.rb
+++ b/libraries/github.rb
@@ -79,7 +79,6 @@ end
 # @param auth_token [String] Jenkins user api token for authentication with
 #   Jenkins server
 #
-# rubocop:disable Metrics/ParameterLists
 def set_up_github_push(github_token, org_name, repo_name, job_name,
                        trigger_token, insecure_hook, auth_user = nil,
                        auth_token = nil)

--- a/spec/unit/libraries/github_spec.rb
+++ b/spec/unit/libraries/github_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../spec_helper'
+
+describe 'libraries/github.rb' do
+  let(:library_path) { File.expand_path('../../../libraries/github.rb', __dir__) }
+
+  describe 'load-time middleware configuration' do
+    # Regression test: when chefspec/berkshelf transitively loads Faraday::HttpCache before
+    # the cookbook's chef_gem 'octokit' has been required, the eager middleware block at the
+    # top of github.rb used to raise `NameError: uninitialized constant Octokit`, which
+    # aborted loading of the rest of the library (helpers.rb, resource.rb, template.rb) and
+    # cascaded into `osl_jenkins_java_version` / `OslJenkins` errors in any cookbook that
+    # depends on osl-jenkins. The fix guards the block on both constants being defined.
+    it 'does not raise when Octokit is not loaded' do
+      hide_const('Octokit')
+      expect { load library_path }.not_to raise_error
+    end
+
+    it 'does not raise when neither Octokit nor Faraday::HttpCache is loaded' do
+      hide_const('Octokit')
+      hide_const('Faraday::HttpCache') if defined?(Faraday::HttpCache)
+      expect { load library_path }.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/recipes/controller_spec.rb
+++ b/spec/unit/recipes/controller_spec.rb
@@ -5,10 +5,10 @@ describe 'jenkins_test::controller' do
     context "#{p[:platform]} #{p[:version]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p.dup.merge(step_into: %w(
-          osl_jenkins_config
-          osl_jenkins_install
-          osl_jenkins_service
-        ))).converge(described_recipe)
+                                               osl_jenkins_config
+                                               osl_jenkins_install
+                                               osl_jenkins_service
+                                             ))).converge(described_recipe)
       end
       include_context 'common_stubs'
       it 'converges successfully' do
@@ -52,7 +52,7 @@ describe 'jenkins_test::controller' do
           default_backend: 'jenkins',
           maxconn: '2000',
           extra_options: {
-              'redirect' => 'scheme https if !{ ssl_fc }',
+            'redirect' => 'scheme https if !{ ssl_fc }',
           }
         )
       end
@@ -120,9 +120,9 @@ describe 'jenkins_test::controller' do
         is_expected.to create_osl_jenkins_config('default').with(
           cookbook: 'osl-jenkins',
           variables: {
-              site_name: '10.0.0.2',
-              admin_address: 'noreply@example.org',
-              num_executors: 2,
+            site_name: '10.0.0.2',
+            admin_address: 'noreply@example.org',
+            num_executors: 2,
           }
         )
       end

--- a/spec/unit/resources/resource_spec.rb
+++ b/spec/unit/resources/resource_spec.rb
@@ -5,13 +5,13 @@ describe 'jenkins_test::resources' do
     context "#{p[:platform]} #{p[:version]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p.dup.merge(step_into: %w(
-          osl_jenkins_client_cert_credentials
-          osl_jenkins_job
-          osl_jenkins_password_credentials
-          osl_jenkins_plugin
-          osl_jenkins_private_key_credentials
-          osl_jenkins_secret
-        ))).converge(described_recipe)
+                                               osl_jenkins_client_cert_credentials
+                                               osl_jenkins_job
+                                               osl_jenkins_password_credentials
+                                               osl_jenkins_plugin
+                                               osl_jenkins_private_key_credentials
+                                               osl_jenkins_secret
+                                             ))).converge(described_recipe)
       end
       include_context 'common_stubs'
 

--- a/spec/webhooks/bumpzone_spec.rb
+++ b/spec/webhooks/bumpzone_spec.rb
@@ -80,7 +80,7 @@ describe BumpZone do
       ]
       allow(github_mock).to receive(:pull_request_files).with('osuosl/zonefiles-test', 1).and_return(response_body)
       files = BumpZone.changed_files(open_json('merge_payload.json'))
-      expect(files[0].filename).to match(/db.osuosl.org/)
+      expect(files.first.filename).to match(/db.osuosl.org/)
       expect(files[1].filename).to match(/db.bak/)
     end
   end

--- a/spec/webhooks/checkzone_spec.rb
+++ b/spec/webhooks/checkzone_spec.rb
@@ -134,7 +134,7 @@ describe CheckZone do
       CheckZone.reset
       CheckZone.github_init(open_json('sync_multifile_payload.json'))
       files = CheckZone.changed_files
-      expect(files[0].filename).to match(/db.osuosl.org/)
+      expect(files.first.filename).to match(/db.osuosl.org/)
       expect(files[1].filename).to match(/db.osuosl.com/)
     end
   end


### PR DESCRIPTION
The top-level block in libraries/github.rb wired up Octokit's middleware
stack whenever Faraday::HttpCache was defined, but Octokit itself was
only required lazily inside the individual methods. When chefspec /
berkshelf loaded Faraday::HttpCache transitively in a dependent
cookbook's test environment (e.g. proj-ros), evaluating this block
raised NameError on Octokit and aborted loading of the rest of the
library, cascading into "uninitialized constant OslJenkins" and
"undefined method osl_jenkins_java_version" errors. Guard the block on
both constants and add a regression spec.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
