### PR TITLE
Add org-folder CI for cookbook repos via cookbook-pipelines

### DIFF
--- a/attributes/cookbook_uploader.rb
+++ b/attributes/cookbook_uploader.rb
@@ -45,6 +45,18 @@ default['osl-jenkins']['cookbook_uploader']['default_environments_word'] = '~'
 # when used in the !bump command.
 default['osl-jenkins']['cookbook_uploader']['all_environments_word'] = '*'
 
+# String; Git URL of the cookbook-pipelines repo, which holds the shared
+# pipeline library (cookbook CI) and the uploader pipeline definitions.
+default['osl-jenkins']['cookbook_uploader']['pipelines_repo'] = 'https://github.com/osuosl/cookbook-pipelines.git'
+
+# String; Branch of the cookbook-pipelines repo that Jenkins runs from.
+default['osl-jenkins']['cookbook_uploader']['pipelines_branch'] = 'main'
+
+# String; Regex of repo names the CI organization folder will consider. Repos
+# not matching are ignored entirely, even if they contain a Jenkinsfile.
+# Useful for canarying CI on one or two repos before an org-wide rollout.
+default['osl-jenkins']['cookbook_uploader']['ci_repo_filter'] = '.*'
+
 ###
 ### Attributes that are mainly for testing:
 ###

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -84,6 +84,39 @@ osl_jenkins_service 'cookbook_uploader' do
   action :nothing
 end
 
+# Cookbook CI: a GitHub Organization Folder discovers every repo in the org
+# with a Jenkinsfile and runs its PRs/branches through the osl-pipelines
+# shared library (replaces the hand-managed GHPRB linter jobs).
+osl_jenkins_plugin 'github-branch-source' do
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
+osl_jenkins_password_credentials 'cookbook_uploader' do
+  username git_cred['user']
+  password git_cred['token']
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
+osl_jenkins_config 'shared_library' do
+  source 'shared_library.yml.erb'
+  variables(
+    branch: node['osl-jenkins']['cookbook_uploader']['pipelines_branch'],
+    repo: node['osl-jenkins']['cookbook_uploader']['pipelines_repo']
+  )
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
+osl_jenkins_job org_name do
+  source 'jobs/cookbook_ci.groovy.erb'
+  template true
+  variables(
+    job_name: org_name,
+    org: org_name,
+    repo_filter: node['osl-jenkins']['cookbook_uploader']['ci_repo_filter']
+  )
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
 env_job_name = "environment-bumper-#{chef_repo.tr('/', '-')}"
 
 osl_jenkins_job env_job_name do

--- a/spec/unit/recipes/cookbook_uploader_spec.rb
+++ b/spec/unit/recipes/cookbook_uploader_spec.rb
@@ -12,6 +12,7 @@ describe 'osl-jenkins::cookbook_uploader' do
             'default_environments' => %w(production workstation),
             'override_repos' => %w(test-cookbook),
             'override_archived_repos' => %w(archived-cookbook),
+            'ci_repo_filter' => 'test-cookbook',
             'github_insecure_hook' => true,
             'do_not_upload_cookbooks' => true,
           }
@@ -72,6 +73,37 @@ describe 'osl-jenkins::cookbook_uploader' do
         end
       end
       it { is_expected.to nothing_osl_jenkins_service 'cookbook_uploader' }
+      it { is_expected.to install_osl_jenkins_plugin 'github-branch-source' }
+      it do
+        is_expected.to create_osl_jenkins_password_credentials('cookbook_uploader').with(
+          username: 'manatee',
+          password: 'token_password'
+        )
+      end
+      it do
+        is_expected.to create_osl_jenkins_config('shared_library').with(
+          source: 'shared_library.yml.erb',
+          variables: {
+            branch: 'main',
+            repo: 'https://github.com/osuosl/cookbook-pipelines.git',
+          }
+        )
+      end
+      it do
+        is_expected.to create_osl_jenkins_job('osuosl-cookbooks').with(
+          source: 'jobs/cookbook_ci.groovy.erb',
+          template: true,
+          variables: {
+            job_name: 'osuosl-cookbooks',
+            org: 'osuosl-cookbooks',
+            repo_filter: 'test-cookbook',
+          }
+        )
+      end
+      it do
+        expect(chef_run.osl_jenkins_job('osuosl-cookbooks')).to \
+          notify('osl_jenkins_service[cookbook_uploader]').to(:restart).delayed
+      end
       it do
         is_expected.to create_osl_jenkins_job('environment-bumper-osuosl-chef-repo').with(
           source: 'jobs/environment-bumper.groovy.erb',

--- a/templates/jobs/cookbook_ci.groovy.erb
+++ b/templates/jobs/cookbook_ci.groovy.erb
@@ -1,0 +1,50 @@
+organizationFolder('<%= @job_name %>') {
+  description('CI for all <%= @org %> cookbooks. Managed by Chef (osl-jenkins) - do not edit in Jenkins.')
+  organizations {
+    github {
+      repoOwner('<%= @org %>')
+      apiUri('https://api.github.com')
+      credentialsId('cookbook_uploader')
+      traits {
+        // Only repos matching this regex are considered (canary control via
+        // the ci_repo_filter attribute).
+        sourceRegexFilter {
+          regex('<%= @repo_filter %>')
+        }
+        gitHubExcludeArchivedRepositories()
+        gitHubBranchDiscovery {
+          // 1 = only branches that are not also filed as PRs
+          strategyId(1)
+        }
+        gitHubPullRequestDiscovery {
+          // 1 = merge the PR with the target branch before building
+          strategyId(1)
+        }
+        gitHubForkDiscovery {
+          strategyId(1)
+          trust {
+            // Only build fork PRs from users with write permission without
+            // manual approval - PR code runs on our infrastructure.
+            gitHubTrustPermissions()
+          }
+        }
+      }
+    }
+  }
+  projectFactories {
+    workflowMultiBranchProjectFactory {
+      scriptPath('Jenkinsfile')
+    }
+  }
+  orphanedItemStrategy {
+    discardOldItems {
+      daysToKeep(7)
+    }
+  }
+  triggers {
+    // Webhooks drive builds; the periodic scan is a safety net.
+    periodicFolderTrigger {
+      interval('1d')
+    }
+  }
+}

--- a/templates/shared_library.yml.erb
+++ b/templates/shared_library.yml.erb
@@ -1,0 +1,13 @@
+unclassified:
+  globalLibraries:
+    libraries:
+      - name: osl-pipelines
+        defaultVersion: <%= @branch %>
+        implicit: false
+        allowVersionOverride: false
+        retriever:
+          modernSCM:
+            scm:
+              git:
+                remote: <%= @repo %>
+                credentialsId: cookbook_uploader

--- a/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
+++ b/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
@@ -14,6 +14,27 @@ control 'cookbook-uploader' do
     its('headers.X-Jenkins') { should_not eq nil }
   end
 
+  describe http('https://127.0.0.1/job/osuosl-cookbooks/', ssl_verify: false) do
+    its('status') { should eq 200 }
+    its('headers.X-Jenkins') { should_not eq nil }
+  end
+
+  describe file('/var/lib/jenkins/casc_configs/shared_library.yml') do
+    its('owner') { should eq 'jenkins' }
+    its('content') { should match(/name: osl-pipelines/) }
+    its('content') { should match(%r{remote: https://github.com/osuosl/cookbook-pipelines.git}) }
+  end
+
+  describe file('/var/lib/jenkins/casc_configs/groovy/job_osuosl-cookbooks.groovy') do
+    its('owner') { should eq 'jenkins' }
+    its('content') { should match(/organizationFolder\('osuosl-cookbooks'\)/) }
+    its('content') { should match(/gitHubTrustPermissions/) }
+  end
+
+  describe file('/var/lib/jenkins/plugins.txt') do
+    its('content') { should match(/^github-branch-source/) }
+  end
+
   describe file('/var/lib/jenkins/bin/github_pr_comment_trigger.rb') do
     its('mode') { should cmp 0550 }
     its('owner') { should eq 'jenkins' }


### PR DESCRIPTION
- github-branch-source plugin
- manage cookbook_uploader credential via osl_jenkins_password_credentials
- osl-pipelines shared library JCasC config (osuosl/cookbook-pipelines)
- organizationFolder job with write-permission trust for fork PRs
- ci_repo_filter attribute to canary CI on specific repos
- pipelines_repo/pipelines_branch attributes
- chefspec and inspec coverage

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
