### PR TITLE
Do not manage cookbook_uploader credential via JCasC

### DIFF
--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -87,13 +87,13 @@ end
 # Cookbook CI: a GitHub Organization Folder discovers every repo in the org
 # with a Jenkinsfile and runs its PRs/branches through the osl-pipelines
 # shared library (replaces the hand-managed GHPRB linter jobs).
+#
+# NOTE: the 'cookbook_uploader' Jenkins credential this job and shared library
+# reference is created out-of-band (Jenkins UI), NOT via JCasC. Do not add an
+# osl_jenkins_password_credentials resource here: JCasC's credentials
+# configurator is authoritative over the entire global credential store and
+# would delete every out-of-band credential on the server on the next restart.
 osl_jenkins_plugin 'github-branch-source' do
-  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
-end
-
-osl_jenkins_password_credentials 'cookbook_uploader' do
-  username git_cred['user']
-  password git_cred['token']
   notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
 end
 

--- a/spec/unit/recipes/cookbook_uploader_spec.rb
+++ b/spec/unit/recipes/cookbook_uploader_spec.rb
@@ -74,12 +74,10 @@ describe 'osl-jenkins::cookbook_uploader' do
       end
       it { is_expected.to nothing_osl_jenkins_service 'cookbook_uploader' }
       it { is_expected.to install_osl_jenkins_plugin 'github-branch-source' }
-      it do
-        is_expected.to create_osl_jenkins_password_credentials('cookbook_uploader').with(
-          username: 'manatee',
-          password: 'token_password'
-        )
-      end
+      # The cookbook_uploader credential is intentionally NOT managed by JCasC
+      # (it is created out-of-band); a JCasC credentials block would wipe the
+      # server's entire credential store on restart.
+      it { is_expected.to_not create_osl_jenkins_password_credentials('cookbook_uploader') }
       it do
         is_expected.to create_osl_jenkins_config('shared_library').with(
           source: 'shared_library.yml.erb',


### PR DESCRIPTION
- JCasC credentials are authoritative over the entire global store;
  declaring one credential deletes all out-of-band (UI-created) ones
  on the next Jenkins restart
- org folder and shared library reference the existing out-of-band
  cookbook_uploader credential instead
- add a warning comment and a negative spec to prevent regressions

Signed-off-by: Lance Albertson <lance@osuosl.org>
