### PR TITLE
Add label-driven cookbook release pipelines and github-sync job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ bin/*
 .kitchen/
 .kitchen.local.yml
 .kitchen.list.yml
+
+# Local agent/editor settings
+.claude/

--- a/chefignore
+++ b/chefignore
@@ -93,3 +93,8 @@ Vagrantfile
 # Travis #
 ##########
 .travis.yml
+
+# Local agent settings #
+########################
+.claude
+*/.claude

--- a/libraries/github.rb
+++ b/libraries/github.rb
@@ -62,6 +62,29 @@ def collect_archived_github_repositories(github_token, org_name)
   github.org_repos(org_name).select(&:archived?).map(&:name)
 end
 
+# Bump/env labels and uploader webhooks are managed by the scheduled
+# github-sync Jenkins job (cookbook-pipelines), not at converge time: doing
+# it here hit GitHub's rate limits and slowed every chef run.
+
+# A Jenkinsfile in the repo root marks a repo as migrated to the label-driven
+# pipeline: its legacy per-repo uploader job config is then deleted instead of
+# generated. (The legacy webhooks are removed by the github-sync job, which
+# owns all GitHub-side state.)
+#
+# @param github_token [String] GitHub API token.
+# @param org_name [String] Name of GitHub organization.
+# @param repo_name [String] Name of GitHub repo within the organization.
+def repo_has_jenkinsfile?(github_token, org_name, repo_name)
+  patch_yajl_workaround
+  require 'octokit'
+
+  github = Octokit::Client.new(access_token: github_token)
+  github.contents("#{org_name}/#{repo_name}", path: 'Jenkinsfile')
+  true
+rescue Octokit::NotFound
+  false
+end
+
 # Sets up a GitHub trigger for the Jenkins cookbook uploader job.  It will
 # trigger whenever a comment is made on a PR/issue and will send a JSON payload
 # of the comment to the specified Jenkins job, using the given trigger token to

--- a/recipes/cookbook_uploader.rb
+++ b/recipes/cookbook_uploader.rb
@@ -97,6 +97,16 @@ osl_jenkins_plugin 'github-branch-source' do
   notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
 end
 
+osl_jenkins_plugin 'generic-webhook-trigger' do
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
+# readJSON for the uploader pipeline; not in the default plugin set, and its
+# absence only surfaces at runtime, after a release is already published.
+osl_jenkins_plugin 'pipeline-utility-steps' do
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
 osl_jenkins_config 'shared_library' do
   source 'shared_library.yml.erb'
   variables(
@@ -117,6 +127,56 @@ osl_jenkins_job org_name do
   notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
 end
 
+# Label-driven release pipeline: one webhook-driven job for every repo in the
+# org. Coexists with the per-repo freestyle jobs until cutover.
+osl_jenkins_job 'cookbook-uploader' do
+  source 'jobs/cookbook_uploader_pipeline.groovy.erb'
+  template true
+  variables(
+    chef_repo: chef_repo,
+    default_environments: node['osl-jenkins']['cookbook_uploader']['default_environments'].join(','),
+    do_not_upload: node['osl-jenkins']['cookbook_uploader']['do_not_upload_cookbooks'].to_s,
+    job_name: 'cookbook-uploader',
+    org: org_name,
+    pipelines_branch: node['osl-jenkins']['cookbook_uploader']['pipelines_branch'],
+    pipelines_repo: node['osl-jenkins']['cookbook_uploader']['pipelines_repo'],
+    trigger_token: jenkins_cred['trigger_token']
+  )
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
+osl_jenkins_job 'environment-bumper' do
+  source 'jobs/environment_bumper_pipeline.groovy.erb'
+  template true
+  variables(
+    chef_repo: chef_repo,
+    default_environments: node['osl-jenkins']['cookbook_uploader']['default_environments'].join(','),
+    job_name: 'environment-bumper',
+    pipelines_branch: node['osl-jenkins']['cookbook_uploader']['pipelines_branch'],
+    pipelines_repo: node['osl-jenkins']['cookbook_uploader']['pipelines_repo']
+  )
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
+# Reconciles GitHub labels/webhooks org-wide on a schedule instead of during
+# converge. Requires the out-of-band 'cookbook_uploader_trigger' secret-text
+# credential — UI-created, never via JCasC (which wipes the credential store).
+osl_jenkins_job 'github-sync' do
+  source 'jobs/github_sync_pipeline.groovy.erb'
+  template true
+  variables(
+    default_environments: node['osl-jenkins']['cookbook_uploader']['default_environments'].join(','),
+    insecure_hook: node['osl-jenkins']['cookbook_uploader']['github_insecure_hook'].to_s,
+    job_name: 'github-sync',
+    org: org_name,
+    pipelines_branch: node['osl-jenkins']['cookbook_uploader']['pipelines_branch'],
+    pipelines_repo: node['osl-jenkins']['cookbook_uploader']['pipelines_repo'],
+    repos: (node['osl-jenkins']['cookbook_uploader']['override_repos'] || []).join(','),
+    webhook_endpoint: "https://#{public_address}/generic-webhook-trigger/invoke"
+  )
+  notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+end
+
 env_job_name = "environment-bumper-#{chef_repo.tr('/', '-')}"
 
 osl_jenkins_job env_job_name do
@@ -133,22 +193,35 @@ osl_jenkins_job env_job_name do
   notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
 end
 
+# A repo with a Jenkinsfile has migrated to the label-driven pipeline: drop
+# its legacy job config instead of creating it. Its legacy webhooks are
+# removed by github-sync. (The leftover job on the Jenkins server itself
+# still needs a one-time manual delete, as with archived repos.)
 repo_names.each do |repo_name|
   job_name = "cookbook-uploader-#{org_name}-#{repo_name}"
-  osl_jenkins_job job_name do
-    source 'jobs/cookbook_uploader.groovy.erb'
-    template true
-    variables(
-      execute_shell: execute_shell,
-      github_url: "https://github.com/#{org_name}/#{repo_name}",
-      job_name: job_name,
-      non_bump_message: non_bump_message,
-      trigger_token: jenkins_cred['trigger_token']
-    )
-    notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
-  end
 
   begin
+    if repo_has_jenkinsfile?(git_cred['token'], org_name, repo_name)
+      osl_jenkins_job job_name do
+        action :delete
+        notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+      end
+      next
+    end
+
+    osl_jenkins_job job_name do
+      source 'jobs/cookbook_uploader.groovy.erb'
+      template true
+      variables(
+        execute_shell: execute_shell,
+        github_url: "https://github.com/#{org_name}/#{repo_name}",
+        job_name: job_name,
+        non_bump_message: non_bump_message,
+        trigger_token: jenkins_cred['trigger_token']
+      )
+      notifies :restart, 'osl_jenkins_service[cookbook_uploader]', :delayed
+    end
+
     set_up_github_push(
       git_cred['token'],
       org_name,
@@ -159,8 +232,11 @@ repo_names.each do |repo_name|
       jenkins_cred['user'],
       jenkins_cred['api_token']
     )
-  rescue Octokit::InternalServerError, Octokit::BadGateway, Octokit::ServerError => e
-    Chef::Log.warn("Unable to connect to Github: #{e}")
+  # Compile-phase GitHub call: degrade any API error to a warning so it can
+  # never abort the converge; the loop is idempotent. On error the legacy job
+  # is kept, never half-removed.
+  rescue Octokit::Error => e
+    Chef::Log.warn("GitHub setup for #{org_name}/#{repo_name} failed: #{e}")
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,5 +79,6 @@ end
 shared_context 'cookbook_uploader' do
   before do
     allow_any_instance_of(Chef::Recipe).to receive(:set_up_github_push)
+    allow_any_instance_of(Chef::Recipe).to receive(:repo_has_jenkinsfile?).and_return(false)
   end
 end

--- a/spec/unit/recipes/cookbook_uploader_spec.rb
+++ b/spec/unit/recipes/cookbook_uploader_spec.rb
@@ -74,6 +74,65 @@ describe 'osl-jenkins::cookbook_uploader' do
       end
       it { is_expected.to nothing_osl_jenkins_service 'cookbook_uploader' }
       it { is_expected.to install_osl_jenkins_plugin 'github-branch-source' }
+      it { is_expected.to install_osl_jenkins_plugin 'generic-webhook-trigger' }
+      it { is_expected.to install_osl_jenkins_plugin 'pipeline-utility-steps' }
+      it do
+        is_expected.to create_osl_jenkins_job('cookbook-uploader').with(
+          source: 'jobs/cookbook_uploader_pipeline.groovy.erb',
+          template: true,
+          variables: {
+            chef_repo: 'osuosl/chef-repo',
+            default_environments: 'production,workstation',
+            do_not_upload: 'true',
+            job_name: 'cookbook-uploader',
+            org: 'osuosl-cookbooks',
+            pipelines_branch: 'main',
+            pipelines_repo: 'https://github.com/osuosl/cookbook-pipelines.git',
+            trigger_token: 'trigger_token',
+          }
+        )
+      end
+      it do
+        expect(chef_run.osl_jenkins_job('cookbook-uploader')).to \
+          notify('osl_jenkins_service[cookbook_uploader]').to(:restart).delayed
+      end
+      it do
+        is_expected.to create_osl_jenkins_job('environment-bumper').with(
+          source: 'jobs/environment_bumper_pipeline.groovy.erb',
+          template: true,
+          variables: {
+            chef_repo: 'osuosl/chef-repo',
+            default_environments: 'production,workstation',
+            job_name: 'environment-bumper',
+            pipelines_branch: 'main',
+            pipelines_repo: 'https://github.com/osuosl/cookbook-pipelines.git',
+          }
+        )
+      end
+      it do
+        expect(chef_run.osl_jenkins_job('environment-bumper')).to \
+          notify('osl_jenkins_service[cookbook_uploader]').to(:restart).delayed
+      end
+      it do
+        is_expected.to create_osl_jenkins_job('github-sync').with(
+          source: 'jobs/github_sync_pipeline.groovy.erb',
+          template: true,
+          variables: {
+            default_environments: 'production,workstation',
+            insecure_hook: 'true',
+            job_name: 'github-sync',
+            org: 'osuosl-cookbooks',
+            pipelines_branch: 'main',
+            pipelines_repo: 'https://github.com/osuosl/cookbook-pipelines.git',
+            repos: 'test-cookbook',
+            webhook_endpoint: 'https://jenkins.osuosl.org/generic-webhook-trigger/invoke',
+          }
+        )
+      end
+      it do
+        expect(chef_run.osl_jenkins_job('github-sync')).to \
+          notify('osl_jenkins_service[cookbook_uploader]').to(:restart).delayed
+      end
       # The cookbook_uploader credential is intentionally NOT managed by JCasC
       # (it is created out-of-band); a JCasC credentials block would wipe the
       # server's entire credential store on restart.
@@ -138,6 +197,41 @@ describe 'osl-jenkins::cookbook_uploader' do
           notify('osl_jenkins_service[cookbook_uploader]').to(:restart).delayed
       end
       it { is_expected.to delete_osl_jenkins_job 'cookbook-uploader-osuosl-cookbooks-archived-cookbook' }
+
+      # A Jenkinsfile marks a repo as migrated to the label-driven pipeline:
+      # its legacy job config and webhook are removed instead of created.
+      context 'when the repo has migrated (Jenkinsfile present)' do
+        cached(:migrated_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.normal['osl-jenkins']['cookbook_uploader'] = {
+              'org' => 'osuosl-cookbooks',
+              'chef_repo' => 'osuosl/chef-repo',
+              'default_environments' => %w(production workstation),
+              'override_repos' => %w(test-cookbook),
+              'override_archived_repos' => %w(archived-cookbook),
+              'ci_repo_filter' => 'test-cookbook',
+              'do_not_upload_cookbooks' => true,
+            }
+            node.normal['osl-jenkins']['credentials']['git'] = {
+              'cookbook_uploader' => { user: 'manatee', token: 'token_password' },
+            }
+            node.normal['osl-jenkins']['credentials']['jenkins'] = {
+              'cookbook_uploader' => {
+                user: 'manatee', api_token: 'api_token', trigger_token: 'trigger_token'
+              },
+            }
+          end.converge(described_recipe, 'osl-jenkins::default')
+        end
+
+        before do
+          allow_any_instance_of(Chef::Recipe).to receive(:repo_has_jenkinsfile?).and_return(true)
+        end
+
+        it 'deletes the legacy job config and skips the legacy webhook setup' do
+          expect_any_instance_of(Chef::Recipe).to_not receive(:set_up_github_push)
+          expect(migrated_run).to delete_osl_jenkins_job('cookbook-uploader-osuosl-cookbooks-test-cookbook')
+        end
+      end
       it do
         expect(chef_run.osl_jenkins_job('cookbook-uploader-osuosl-cookbooks-archived-cookbook')).to \
           notify('osl_jenkins_service[cookbook_uploader]').to(:restart).delayed

--- a/templates/jobs/cookbook_uploader_pipeline.groovy.erb
+++ b/templates/jobs/cookbook_uploader_pipeline.groovy.erb
@@ -1,0 +1,59 @@
+pipelineJob('<%= @job_name %>') {
+  description('Label/comment-driven cookbook release pipeline for all <%= @org %> repos. Managed by Chef (osl-jenkins) - do not edit in Jenkins.')
+  parameters {
+    stringParam('GITHUB_ORG', '<%= @org %>', 'GitHub organization containing the cookbooks.')
+    stringParam('CHEF_REPO', '<%= @chef_repo %>', 'org/name of the chef-repo.')
+    stringParam('DEFAULT_ENVIRONMENTS', '<%= @default_environments %>', 'Comma list expanded by the env/default label.')
+    stringParam('DO_NOT_UPLOAD', '<%= @do_not_upload %>', "Set to 'true' to skip knife uploads (testing).")
+  }
+  definition {
+    cpsScm {
+      scm {
+        git {
+          remote {
+            url('<%= @pipelines_repo %>')
+            credentials('cookbook_uploader')
+          }
+          branches('*/<%= @pipelines_branch %>')
+        }
+      }
+      scriptPath('pipelines/cookbook-uploader.Jenkinsfile')
+      lightweight(true)
+    }
+  }
+  properties {
+    pipelineTriggers {
+      triggers {
+        genericTrigger {
+          genericVariables {
+            genericVariable {
+              key('payload')
+              value('$')
+              expressionType('JSONPath')
+            }
+            genericVariable {
+              key('gh_action')
+              value('$.action')
+              expressionType('JSONPath')
+            }
+            genericVariable {
+              key('gh_label')
+              value('$.label.name')
+              expressionType('JSONPath')
+            }
+          }
+          token('<%= @trigger_token %>')
+          printContributedVariables(false)
+          printPostContent(false)
+          silentResponse(true)
+          // Build only when a bump/* label is added. Anchored because the
+          // plugin matches with find() and 'unlabeled' payloads still carry
+          // the label. No !bump comment path until cutover: the legacy jobs
+          // own issue_comment and matching it here would double-release.
+          regexpFilterText('$gh_action:$gh_label')
+          regexpFilterExpression('^labeled:bump/(major|minor|patch)$')
+        }
+      }
+    }
+  }
+}

--- a/templates/jobs/environment_bumper_pipeline.groovy.erb
+++ b/templates/jobs/environment_bumper_pipeline.groovy.erb
@@ -1,0 +1,26 @@
+pipelineJob('<%= @job_name %>') {
+  description('Pins cookbook versions in chef-repo environments and opens/updates a PR. Managed by Chef (osl-jenkins) - do not edit in Jenkins.')
+  parameters {
+    stringParam('cookbooks', '', "Comma list of name:version pins, e.g. 'osl-postfix:2.1.0,postfix:6.1.8'.")
+    stringParam('envs', '', "Comma list of chef environments; 'all' updates existing pins in every environment, 'default' expands to the default set. Named environments (and the default set) also gain missing pins.")
+    stringParam('chain', '', 'Optional chain name; bumps sharing a chain accumulate in one chef-repo PR.')
+    stringParam('pr_link', '', 'Optional link to the PR that triggered this bump.')
+    stringParam('CHEF_REPO', '<%= @chef_repo %>', 'org/name of the chef-repo.')
+    stringParam('DEFAULT_ENVIRONMENTS', '<%= @default_environments %>', "Comma list expanded by the 'default' env word.")
+  }
+  definition {
+    cpsScm {
+      scm {
+        git {
+          remote {
+            url('<%= @pipelines_repo %>')
+            credentials('cookbook_uploader')
+          }
+          branches('*/<%= @pipelines_branch %>')
+        }
+      }
+      scriptPath('pipelines/environment-bumper.Jenkinsfile')
+      lightweight(true)
+    }
+  }
+}

--- a/templates/jobs/github_sync_pipeline.groovy.erb
+++ b/templates/jobs/github_sync_pipeline.groovy.erb
@@ -1,0 +1,37 @@
+pipelineJob('<%= @job_name %>') {
+  description('Seeds bump/env labels and the uploader webhook across all <%= @org %> repos. Managed by Chef (osl-jenkins) - do not edit in Jenkins.')
+  parameters {
+    stringParam('GITHUB_ORG', '<%= @org %>', 'GitHub organization whose repos are synced.')
+    stringParam('DEFAULT_ENVIRONMENTS', '<%= @default_environments %>', 'Comma list; each gets an env/<name> label.')
+    stringParam('REPOS', '<%= @repos %>', 'Comma list of repos to sync; empty means every non-archived repo in the org.')
+    booleanParam('DRY_RUN', false, 'Report what would change without writing to GitHub.')
+    stringParam('PROTECT_BRANCHES', 'true', "Set to 'false' to skip restricting default-branch merges to the bot account.")
+    stringParam('WEBHOOK_ENDPOINT', '<%= @webhook_endpoint %>', 'generic-webhook-trigger invoke URL (token appended from the credential).')
+    stringParam('INSECURE_HOOK', '<%= @insecure_hook %>', "Set to 'true' to allow insecure SSL on the webhook (testing only).")
+  }
+  properties {
+    pipelineTriggers {
+      triggers {
+        cron {
+          // Every 30 minutes, offset from the chef-client interval.
+          spec('15,45 * * * *')
+        }
+      }
+    }
+  }
+  definition {
+    cpsScm {
+      scm {
+        git {
+          remote {
+            url('<%= @pipelines_repo %>')
+            credentials('cookbook_uploader')
+          }
+          branches('*/<%= @pipelines_branch %>')
+        }
+      }
+      scriptPath('pipelines/github-sync.Jenkinsfile')
+      lightweight(true)
+    }
+  }
+}

--- a/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
+++ b/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
@@ -19,6 +19,30 @@ control 'cookbook-uploader' do
     its('headers.X-Jenkins') { should_not eq nil }
   end
 
+  describe http('https://127.0.0.1/job/cookbook-uploader/', ssl_verify: false) do
+    its('status') { should eq 200 }
+    its('headers.X-Jenkins') { should_not eq nil }
+  end
+
+  describe http('https://127.0.0.1/job/environment-bumper/', ssl_verify: false) do
+    its('status') { should eq 200 }
+    its('headers.X-Jenkins') { should_not eq nil }
+  end
+
+  describe http('https://127.0.0.1/job/github-sync/', ssl_verify: false) do
+    its('status') { should eq 200 }
+    its('headers.X-Jenkins') { should_not eq nil }
+  end
+
+  describe file('/var/lib/jenkins/casc_configs/groovy/job_cookbook-uploader.groovy') do
+    its('owner') { should eq 'jenkins' }
+    its('content') { should match(/pipelineJob\('cookbook-uploader'\)/) }
+    its('content') { should match(/genericTrigger/) }
+    its('content') { should match(%r{\^labeled:bump/\(major\|minor\|patch\)\$}) }
+    # The comment path must stay off while the legacy freestyle jobs exist.
+    its('content') { should_not match(/gh_comment/) }
+  end
+
   describe file('/var/lib/jenkins/casc_configs/shared_library.yml') do
     its('owner') { should eq 'jenkins' }
     its('content') { should match(/name: osl-pipelines/) }
@@ -33,6 +57,8 @@ control 'cookbook-uploader' do
 
   describe file('/var/lib/jenkins/plugins.txt') do
     its('content') { should match(/^github-branch-source/) }
+    its('content') { should match(/^generic-webhook-trigger/) }
+    its('content') { should match(/^pipeline-utility-steps/) }
   end
 
   describe file('/var/lib/jenkins/bin/github_pr_comment_trigger.rb') do


### PR DESCRIPTION
Squashed to one commit. Second phase of the cookbook automation modernization (follows the org-folder CI in #249): the label-driven release pipeline plus the scheduled GitHub reconciliation job, deployed **alongside** the existing per-repo freestyle jobs.

## New Jenkins jobs (JCasC job-dsl → cookbook-pipelines `main`)
- **`cookbook-uploader`** — one webhook-driven pipeline for the whole org. The generic-webhook-trigger regexp is anchored to `bump/major|minor|patch` *label added* events only; no `!bump` comment path until cutover (the legacy jobs own `issue_comment`, and matching it here would double-release).
- **`environment-bumper`** — parameterized pipeline, manual runs supported.
- **`github-sync`** — every 30 min (`15,45 * * * *`, offset from chef runs) + manual: seeds `bump/*`/`env/*` labels, manages the uploader webhooks, removes legacy webhooks from migrated repos, and restricts default-branch merges to the bot. `DRY_RUN` + `REPOS` parameters; `PROTECT_BRANCHES=false` opt-out.

## Per-repo migration
A `Jenkinsfile` in a repo marks it migrated: its legacy freestyle job config is deleted instead of generated (leftover server-side job needs a one-time manual delete, as with archived repos). Legacy webhook removal is github-sync's job. Converge no longer mutates GitHub state — the label/hook helpers moved to cookbook-pipelines.

## Plugins
`generic-webhook-trigger`, `pipeline-utility-steps` (readJSON — absent it only fails at runtime, post-release).

## Notes
- No JCasC `credentials:` block anywhere (see #250). Requires the **out-of-band `cookbook_uploader_trigger` secret-text credential** (the trigger token) created in the Jenkins UI before github-sync can run.
- Merge osuosl/cookbook-pipelines#3 first.
- First github-sync run: `DRY_RUN=true`, review the plan, then `REPOS=<canary>`, then org-wide.
- Docs PR: osuosl/docs (label workflow + migration guide), to merge after this deploys.

## Testing
cookstyle clean; 492 chefspec examples. Kitchen `cookbook-uploader` suite should be run before merge (new job-dsl only fails at Jenkins boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)