### PR TITLE
Trigger the uploader pipeline on bump/skip as well

### DIFF
--- a/templates/jobs/cookbook_uploader_pipeline.groovy.erb
+++ b/templates/jobs/cookbook_uploader_pipeline.groovy.erb
@@ -51,7 +51,7 @@ pipelineJob('<%= @job_name %>') {
           // the label. No !bump comment path until cutover: the legacy jobs
           // own issue_comment and matching it here would double-release.
           regexpFilterText('$gh_action:$gh_label')
-          regexpFilterExpression('^labeled:bump/(major|minor|patch)$')
+          regexpFilterExpression('^labeled:bump/(major|minor|patch|skip)$')
         }
       }
     }

--- a/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
+++ b/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
@@ -38,7 +38,7 @@ control 'cookbook-uploader' do
     its('owner') { should eq 'jenkins' }
     its('content') { should match(/pipelineJob\('cookbook-uploader'\)/) }
     its('content') { should match(/genericTrigger/) }
-    its('content') { should match(%r{\^labeled:bump/\(major\|minor\|patch\)\$}) }
+    its('content') { should match(%r{\^labeled:bump/\(major\|minor\|patch\|skip\)\$}) }
     # The comment path must stay off while the legacy freestyle jobs exist.
     its('content') { should_not match(/gh_comment/) }
   end


### PR DESCRIPTION
Small companion to osuosl/cookbook-pipelines#4, which adds a `bump/skip` label that merges a PR with no release (for changes that don't affect production cookbook code).

The generic-webhook-trigger filter is anchored, so `bump/skip` has to be added explicitly or labeling does nothing:

```
- regexpFilterExpression('^labeled:bump/(major|minor|patch)$')
+ regexpFilterExpression('^labeled:bump/(major|minor|patch|skip)$')
```

InSpec assertion updated to match. **Merge cookbook-pipelines#4 first** — until then the trigger would fire for `bump/skip` and the pipeline wouldn't know what to do with it.

cookstyle clean; 492 chefspec examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)