### PR TITLE
data-bags: build only the default branch

### DIFF
--- a/templates/jobs/data_bags_pipeline.groovy.erb
+++ b/templates/jobs/data_bags_pipeline.groovy.erb
@@ -1,5 +1,5 @@
 multibranchPipelineJob('<%= @job_name %>') {
-  description('CI and deploy for the private data_bags repo on git.osuosl.org: validates every branch/MR via the Jenkinsfile in the repo and uploads the bags to the chef server from the primary branch. Managed by Chef (osl-jenkins) - do not edit in Jenkins.')
+  description('Deploy pipeline for the private data_bags repo on git.osuosl.org: builds only the default branch, validating and uploading the bags to the chef server on every merge. MRs are validated by GitLab CI, not here. Managed by Chef (osl-jenkins) - do not edit in Jenkins.')
   branchSources {
     branchSource {
       source {
@@ -10,18 +10,20 @@ multibranchPipelineJob('<%= @job_name %>') {
           projectPath('<%= @project_path %>')
           traits {
             gitLabBranchDiscovery {
-              // 1 = only branches that are not also filed as MRs
-              strategyId(1)
+              // 3 = all branches; the regex filter below narrows discovery
+              // to the default branch, so nothing else ever builds here
+              strategyId(3)
             }
-            gitLabOriginDiscovery {
-              // 1 = merge the MR with the target branch before building
-              strategyId(1)
+            // Jenkins only deploys merged work; MR validation belongs to
+            // GitLab CI (which runs the same check.rb). Covers both names
+            // so a master -> main rename needs no change here.
+            headRegexFilter {
+              regex('master|main')
             }
-            // No fork MR discovery: the repo is private and never forked,
-            // and builds can reach the chef server credentials on this
-            // controller. Checkout happens over SSH with the same key the
-            // old freestyle job used; the API token is only for the GitLab
-            // API and webhook management.
+            // No MR discovery at all, and builds can reach the chef server
+            // credentials on this controller. Checkout happens over SSH
+            // with the same key the old freestyle job used; the API token
+            // is only for the GitLab API and webhook management.
             gitLabSshCheckout {
               credentialsId('<%= @checkout_credential %>')
             }

--- a/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
+++ b/test/integration/cookbook-uploader/controls/cookbook_uploader_spec.rb
@@ -98,6 +98,9 @@ control 'cookbook-uploader' do
     its('content') { should match(/multibranchPipelineJob\('data-bags'\)/) }
     its('content') { should match(/serverName\('git.osuosl.org'\)/) }
     its('content') { should match(/gitLabSshCheckout/) }
+    # Only the default branch builds; MRs are validated by GitLab CI.
+    its('content') { should match(/headRegexFilter/) }
+    its('content') { should_not match(/gitLabOriginDiscovery/) }
   end
 
   # The legacy trigger scripts are retired along with the freestyle jobs.


### PR DESCRIPTION
The data-bags multibranch job now only ever discovers the default branch: MR discovery is removed and branch discovery is narrowed with a `headRegexFilter('master|main')` (full-match, so a master → main rename needs no change here). Jenkins' role reduces to what it should be — re-validate and deploy on every merge — while GitLab CI, which runs the same checks, becomes the sole merge request gate.

## Deployment notes

- After converge, the job's existing MR/branch items become orphans and age out via the 7-day orphaned-item policy (or delete them at the next scan).
- Since Jenkins no longer reports any status on MRs, consider enabling **"Pipelines must succeed"** in the data_bags project's merge request settings so failing GitLab CI blocks the merge — one-time GitLab UI setting.
- Companion comment-only update in the data_bags repo (Jenkinsfile header + .gitlab-ci.yml).

## Test

- `headRegexFilter` symbol and full-match semantics verified against the scm-api plugin source
- Inspec asserts the filter is present and MR discovery is gone; chefspec 594 examples, 0 failures; cookstyle clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)